### PR TITLE
Fixed panic in mock multi-Op RunAtomically()

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -29,7 +29,7 @@ func newOp(f func(mockOp) error) mockOp {
 }
 
 func (m mockOp) Add(ops ...Op) Op {
-	return multiOp{m}.Add(ops...)
+	return mockMultiOp{m}.Add(ops...)
 }
 
 func (m mockOp) Run() error {
@@ -63,6 +63,65 @@ func (m mockOp) QueryExecutor() QueryExecutor {
 
 func (m mockOp) Preflight() error {
 	return m.preflightErr
+}
+
+type mockMultiOp []Op
+
+func (mo mockMultiOp) Run() error {
+	if err := mo.Preflight(); err != nil {
+		return err
+	}
+	for _, op := range mo {
+		if err := op.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mo mockMultiOp) RunAtomically() error {
+	return mo.Run()
+}
+
+func (mo mockMultiOp) GenerateStatement() (string, []interface{}) {
+	return "", []interface{}{}
+}
+
+func (mo mockMultiOp) QueryExecutor() QueryExecutor {
+	return nil
+}
+
+func (mo mockMultiOp) Add(inOps ...Op) Op {
+	ops := make(mockMultiOp, 0, len(inOps))
+	for _, op := range inOps {
+		// If any multiOps were passed, flatten them out
+		switch op := op.(type) {
+		case mockMultiOp:
+			ops = append(ops, op...)
+		case mockOp:
+			ops = append(ops, op)
+		default:
+			panic("can't Add non-mock ops to mockMultiOp")
+		}
+	}
+	return append(mo, ops...)
+}
+
+func (mo mockMultiOp) WithOptions(opts Options) Op {
+	result := make(mockMultiOp, len(mo))
+	for i, op := range mo {
+		result[i] = op.WithOptions(opts)
+	}
+	return result
+}
+
+func (mo mockMultiOp) Preflight() error {
+	for _, op := range mo {
+		if err := op.Preflight(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (ks *mockKeySpace) NewTable(name string, entity interface{}, fields map[string]interface{}, keys Keys) Table {

--- a/mock_test.go
+++ b/mock_test.go
@@ -110,6 +110,7 @@ func (s *MockSuite) TestTableRead() {
 	s.Equal(u4, u)
 
 	s.NoError(op1.Add(op2).Run())
+	s.NoError(op1.Add(op2).RunAtomically())
 }
 
 func (s *MockSuite) TestTableUpdate() {


### PR DESCRIPTION
Before, when you wanted a mock multi-op to RunAtomically, the non-mock
multiOp would try to use the always-nil QueryExecutor and would panic.
This introduces a mocked multi-op to, like the mockOp, just use Run in
place of RunAtomically.