### PR TITLE
multiOp enhacements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.7
-  - tip
+  - 1.8
 
 services:
   - cassandra

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
+  - tip
 
 services:
   - cassandra

--- a/multiop.go
+++ b/multiop.go
@@ -54,7 +54,12 @@ func (mo multiOp) Add(ops_ ...Op) Op {
 	if len(ops_) == 0 {
 		return mo
 	} else if len(mo) == 0 {
-		return ops_[0].Add(ops_[1:]...)
+		switch len(ops_) {
+		case 1:
+			return ops_[0]
+		default:
+			return ops_[0].Add(ops_[1:]...)
+		}
 	}
 
 	for _, op := range ops_ {


### PR DESCRIPTION
This is a couple of very small optimisations to the code of `multiOp`, which both benefit performance and make testing work a little better.

Currently, `multiOp` and `RunAtomically()` don't play well together, because `mockOp` does not support `QueryExecutor()`, which `multiOp` tries to use. While this doesn't really "fix" the situation, it makes it a bit less likely to occur by "flattening out" `multiOp`s more aggressively, which can result in its `RunAtomically` method never being executed.

This is a bit gross, but I don't have the time right now to embark on a full-scale refactor of how mocking works (which is what's really needed here). 😷 