### PR TITLE
support maps that are not map[string]interface{}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6.2
   - 1.7
   - tip
 


### PR DESCRIPTION
The reflect code in gocassa does not treat maps in any special way when
converting structs to maps for internal use. This means that if your
struct has a map[string]string, it will remain a map[string]string.
However when using MapSetFields the requested changes are in a
map[string]interface{} so we need to ensure that when we copy from
MapSetFields map[string]interface{} to the record value that we don't
assume the map in the record is also a map[string]interface{}, but could
be, for example, a map[string]string.

Note that my knowledge of gocassa is limited so do verify I'm fixing this in the right place. This change does fix it for my code (I had a map[string]string that I did a mutation on).