### PR TITLE
Add new multikey timeseries table

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -19,6 +19,7 @@ type KeySpace interface {
 	MultimapMultiKeyTable(tableName string, fieldToIndexBy, uniqueKey []string, row interface{}) MultimapMkTable
 	TimeSeriesTable(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) TimeSeriesTable
 	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
+	MultiKeyTimeSeriesTable(tableName string, fieldToIndexByField []string, timeField string, uniqueKey []string, bucketSize time.Duration, row interface{}) MultiKeyTimeSeriesTable
 	FlakeSeriesTable(tableName, idField string, bucketSize time.Duration, row interface{}) FlakeSeriesTable
 	MultiFlakeSeriesTable(tableName, indexField, idField string, bucketSize time.Duration, row interface{}) MultiFlakeSeriesTable
 	Table(tableName string, row interface{}, keys Keys) Table
@@ -113,6 +114,20 @@ type MultiTimeSeriesTable interface {
 	List(v interface{}, start, end time.Time, pointerToASlice interface{}) Op
 	Buckets(v interface{}, start time.Time) Buckets
 	WithOptions(Options) MultiTimeSeriesTable
+	Table() Table
+	TableChanger
+}
+
+// MultiKeyTimeSeriesTable is a cross between TimeSeries and MultimapMkTable tables.
+type MultiKeyTimeSeriesTable interface {
+	// timeField and idField must be present
+	Set(v interface{}) Op
+	Update(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}, m map[string]interface{}) Op
+	Delete(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}) Op
+	Read(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}, pointer interface{}) Op
+	List(v map[string]interface{}, start, end time.Time, pointerToASlice interface{}) Op
+	Buckets(v map[string]interface{}, start time.Time) Buckets
+	WithOptions(Options) MultiKeyTimeSeriesTable
 	Table() Table
 	TableChanger
 }

--- a/multikey_timeseries_table.go
+++ b/multikey_timeseries_table.go
@@ -1,0 +1,129 @@
+package gocassa
+
+import (
+	"time"
+)
+
+type multiKeyTimeSeriesT struct {
+	t           Table
+	indexFields []string
+	timeField   string
+	idFields    []string
+	bucketSize  time.Duration
+}
+
+func (o *multiKeyTimeSeriesT) Table() Table                     { return o.t }
+func (o *multiKeyTimeSeriesT) Create() error                    { return o.Table().Create() }
+func (o *multiKeyTimeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
+func (o *multiKeyTimeSeriesT) Name() string                     { return o.Table().Name() }
+func (o *multiKeyTimeSeriesT) Recreate() error                  { return o.Table().Recreate() }
+func (o *multiKeyTimeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
+func (o *multiKeyTimeSeriesT) CreateIfNotExistStatement() (string, error) {
+	return o.Table().CreateIfNotExistStatement()
+}
+
+func (o *multiKeyTimeSeriesT) Set(v interface{}) Op {
+	m, ok := toMap(v)
+	if !ok {
+		panic("Can't set: not able to convert")
+	}
+	if tim, ok := m[o.timeField].(time.Time); !ok {
+		panic("timeField is not actually a time.Time")
+	} else {
+		m[bucketFieldName] = bucket(tim, o.bucketSize)
+	}
+	return o.Table().
+		Set(m)
+}
+
+func (o *multiKeyTimeSeriesT) Update(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}, m map[string]interface{}) Op {
+	bucket := bucket(timeStamp, o.bucketSize)
+	relations := make([]Relation, 0)
+	relations = append(relations, o.ListOfEqualRelations(v, id)...)
+	relations = append(relations, Eq(bucketFieldName, bucket))
+	relations = append(relations, Eq(o.timeField, timeStamp))
+
+	return o.Table().
+		Where(relations...).
+		Update(m)
+}
+
+func (o *multiKeyTimeSeriesT) Delete(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}) Op {
+	bucket := bucket(timeStamp, o.bucketSize)
+	relations := make([]Relation, 0)
+	relations = append(relations, o.ListOfEqualRelations(v, id)...)
+	relations = append(relations, Eq(bucketFieldName, bucket))
+	relations = append(relations, Eq(o.timeField, timeStamp))
+
+	return o.Table().
+		Where(relations...).
+		Delete()
+}
+
+func (o *multiKeyTimeSeriesT) Read(v map[string]interface{}, timeStamp time.Time, id map[string]interface{}, pointer interface{}) Op {
+	bucket := bucket(timeStamp, o.bucketSize)
+	relations := make([]Relation, 0)
+	relations = append(relations, o.ListOfEqualRelations(v, id)...)
+	relations = append(relations, Eq(bucketFieldName, bucket))
+	relations = append(relations, Eq(o.timeField, timeStamp))
+
+	return o.Table().
+		Where(relations...).
+		ReadOne(pointer)
+
+}
+
+func (o *multiKeyTimeSeriesT) List(v map[string]interface{}, startTime time.Time, endTime time.Time, pointerToASlice interface{}) Op {
+	buckets := []interface{}{}
+	for bucket := o.Buckets(v, startTime); bucket.Bucket().Before(endTime); bucket = bucket.Next() {
+		buckets = append(buckets, bucket.Bucket())
+	}
+
+	relations := make([]Relation, 0)
+	relations = append(relations, o.ListOfEqualRelations(v, nil)...)
+	relations = append(relations, In(bucketFieldName, buckets...))
+	relations = append(relations, GTE(o.timeField, startTime))
+	relations = append(relations, LTE(o.timeField, endTime))
+
+	return o.Table().
+		Where(relations...).
+		Read(pointerToASlice)
+}
+
+func (o *multiKeyTimeSeriesT) Buckets(v map[string]interface{}, start time.Time) Buckets {
+	return bucketIter{
+		v:         start,
+		step:      o.bucketSize,
+		field:     bucketFieldName,
+		invariant: o.Table().Where(o.ListOfEqualRelations(v, nil)...)}
+}
+
+func (o *multiKeyTimeSeriesT) WithOptions(opt Options) MultiKeyTimeSeriesTable {
+	return &multiKeyTimeSeriesT{
+		t:           o.Table().WithOptions(opt),
+		indexFields: o.indexFields,
+		timeField:   o.timeField,
+		idFields:    o.idFields,
+		bucketSize:  o.bucketSize,
+	}
+}
+
+func (o *multiKeyTimeSeriesT) ListOfEqualRelations(fieldsToIndex, ids map[string]interface{}) []Relation {
+	relations := make([]Relation, 0)
+
+	for _, field := range o.indexFields {
+		if value := fieldsToIndex[field]; value != nil && value != "" {
+			relation := Eq(field, value)
+			relations = append(relations, relation)
+		}
+	}
+
+	for _, field := range o.idFields {
+		if value := ids[field]; value != nil && value != "" {
+			relation := Eq(field, value)
+			relations = append(relations, relation)
+		}
+	}
+
+	return relations
+}

--- a/multikey_timeseries_table_test.go
+++ b/multikey_timeseries_table_test.go
@@ -1,0 +1,112 @@
+package gocassa
+
+import (
+	"testing"
+	"time"
+)
+
+type TripC struct {
+	Id   string
+	Time time.Time
+	TagA string
+	TagB string
+}
+
+func TestMultiKeyTimeSeriesTable(t *testing.T) {
+	tbl := ns.MultiKeyTimeSeriesTable(
+		"tripTime6",
+		[]string{"TagA", "TagB"},
+		"Time",
+		[]string{"Id"},
+		time.Minute,
+		TripC{},
+	)
+	createIf(tbl.(TableChanger), t)
+	err := tbl.WithOptions(Options{TTL: 30 * time.Second}).Set(TripC{
+		Id:   "1",
+		Time: parse("2006 Jan 2 15:03:59"),
+		TagA: "A",
+		TagB: "A",
+	}).Add(tbl.Set(TripC{
+		Id:   "2",
+		Time: parse("2006 Jan 2 15:04:00"),
+		TagA: "B",
+		TagB: "B",
+	})).Add(tbl.Set(TripC{
+		Id:   "3",
+		Time: parse("2006 Jan 2 15:04:01"),
+		TagA: "A",
+		TagB: "B",
+	})).Add(tbl.Set(TripC{
+		Id:   "4",
+		Time: parse("2006 Jan 2 15:05:01"),
+		TagA: "B",
+		TagB: "B",
+	})).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := &[]TripC{}
+	err = tbl.List(map[string]interface{}{
+		"TagA": "A",
+		"TagB": "A",
+	}, parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"), ts).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*ts) != 1 {
+		t.Fatal(ts)
+	}
+	ts1 := *ts
+	if ts1[0].Id != "1" {
+		t.Fatal(ts1[0])
+	}
+	err = tbl.List(map[string]interface{}{
+		"TagA": "B",
+		"TagB": "B",
+	}, parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:04:02"), ts).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*ts) != 1 {
+		t.Fatal(ts)
+	}
+	ts1 = *ts
+	if ts1[0].Id != "2" {
+		t.Fatal(ts1[0])
+	}
+	err = tbl.List(map[string]interface{}{
+		"TagA": "B",
+		"TagB": "B",
+	}, parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:02"), ts).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*ts) != 2 {
+		t.Fatal(ts)
+	}
+	err = tbl.List(map[string]interface{}{
+		"TagA": "B",
+		"TagB": "B",
+	}, parse("2006 Jan 2 15:03:58"), parse("2006 Jan 2 15:05:00"), ts).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*ts) != 1 {
+		t.Fatal(ts)
+	}
+
+	trip := &TripC{}
+	err = tbl.Read(map[string]interface{}{
+		"TagA": "A",
+		"TagB": "B",
+	}, parse("2006 Jan 2 15:04:01"), map[string]interface{}{
+		"Id": "3",
+	}, trip).Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trip.Id != "3" {
+		t.Fatal(ts)
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -36,6 +36,12 @@ func init() {
 	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
 	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{
 		NumRetries: 3}
+	cluster.ProtoVersion = 3
+	cluster.DisableInitialHostLookup = true
+	cluster.IgnorePeerAddr = true
+	cluster.Events.DisableNodeStatusEvents = true
+	cluster.Events.DisableSchemaEvents = true
+	cluster.Events.DisableTopologyEvents = true
 	sess, err := cluster.CreateSession()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR adds a new recipe which is a combination of the timeseries and MultimapMkTable tables, this recipe lets you create a timeseries which uses composite keys.