### PR TITLE
Persist mutex over MockTable.WithOptions

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -130,6 +130,7 @@ func (ks *mockKeySpace) NewTable(name string, entity interface{}, fields map[str
 		entity: entity,
 		keys:   keys,
 		rows:   map[rowKey]*btree.BTree{},
+		mtx:    &sync.RWMutex{},
 	}
 }
 
@@ -144,7 +145,7 @@ type MockTable struct {
 	sync.RWMutex
 
 	// rows is mapping from row key to column group key to column map
-	mtx     sync.RWMutex
+	mtx     *sync.RWMutex
 	name    string
 	rows    map[rowKey]*btree.BTree
 	entity  interface{}
@@ -357,6 +358,7 @@ func (t *MockTable) WithOptions(o Options) Table {
 		entity:  t.entity,
 		keys:    t.keys,
 		options: t.options.Merge(o),
+		mtx:     t.mtx,
 	}
 }
 


### PR DESCRIPTION
This pull request fixes a bug in the method `MockTable.WithOptions`.

The Gocassa `MockTable` implementation uses a `map` to store the table's `rows`. In Go, [`map` operations are not safe for concurrent use](https://golang.org/doc/faq#atomic_maps), so `MapTable` stores a `sync.RWMutex`, named `mtx` to stop concurrent access to `rows`.

`MockTable` implements a method, `WithOptions`, which returns a *new* `MockTable`, with the supplied options. When this new `MockTable` is constructed, `rows` is passed over. Because `rows` is a `map`, it is passed by reference. Both the old and new `MockTable`s read and write data from the *same* `map`.

Previously, `WithOptions` returned a new `MockTable` with a *new* mutex. There would be two `MockTables` reading and writing to the same `map`, which were synchronised with different mutexes.

This PR makes changes so the `WithOptions` passes the mutex to the new `MockTable` constructor.