### PR TITLE
🔧refer to result set by selection alias

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -209,7 +209,7 @@ func (k *k) Tables() ([]string, error) {
 	}
 	ret := []string{}
 	for _, m := range maps {
-		ret = append(ret, m["columnfamily_name"].(string))
+		ret = append(ret, m["table_name"].(string))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
In 0dffc2c5e617a2f58365ae90fcb800a331d67d7f this was updated from selecting from `system.schema_columnfamilies` to selecting from `columnfamily_name`, and the field selected changed from a column family name to a table name.

This indexes the result map with the new selection, allowing the tests to run.