### PR TITLE
Fixes MultikeyTimeseries mock table

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -142,8 +142,8 @@ func (k *k) MultiKeyTimeSeriesTable(name string, indexFields []string, timeField
 		panic("Unrecognized row type")
 	}
 
-	partitionKeys := []string{bucketFieldName}
-	partitionKeys = append(partitionKeys, indexFields...)
+	partitionKeys := indexFields
+	partitionKeys = append(partitionKeys, bucketFieldName)
 	clusteringColumns := []string{timeField}
 	clusteringColumns = append(clusteringColumns, idFields...)
 


### PR DESCRIPTION
I'm not sure why the bucket should be the last key, but [this](https://github.com/monzo/gocassa/blob/master/mock.go#L416) is checking for it.

This adds `bucket` as the last key when creating a `MultiKeyTimeseries` table and some mock tests. 