### PR TITLE
Add MapSetField support to the mock

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -602,6 +602,15 @@ func assignRecords(m map[string]interface{}, record map[string]interface{}) erro
 					targetMap.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v))
 				}
 				record[k] = targetMap.Interface()
+			case modifierMapSetField:
+				key := v.args[0].(string)
+				value := v.args[1]
+				r := make(map[string]interface{})
+				if record[k] != nil {
+					r = record[k].(map[string]interface{})
+				}
+				r[key] = value
+				record[k] = r
 			case modifierCounterIncrement:
 				oldV, _ := record[k].(int64)
 				delta := int64(v.args[0].(int))


### PR DESCRIPTION
This PR adds support for the `MapSetField` modifier to the gocassa Mock. 

It's _very WIP_ - it fixes the broken test I'm trying to fix, but I'm not sure if it's generalisable as I'm lacking a lot of context on how gocassa fits together. 

It's also untested - I'm opening this to get initial feedback and I'll add tests later.