### PR TITLE
Add context to Options, allowing per query contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
   - java -version
   - sudo rm -rf /var/lib/cassandra/*
-  - wget http://www.us.apache.org/dist/cassandra/3.0.14/apache-cassandra-3.0.14-bin.tar.gz && tar -xvzf apache-cassandra-3.0.14-bin.tar.gz
-  - sudo sh ./apache-cassandra-3.0.14/bin/cassandra -R
+  - wget http://www.us.apache.org/dist/cassandra/3.0.16/apache-cassandra-3.0.16-bin.tar.gz && tar -xvzf apache-cassandra-3.0.16-bin.tar.gz
+  - sudo sh ./apache-cassandra-3.0.16/bin/cassandra -R
   - sleep 20

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"context"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -54,9 +55,11 @@ type Options struct {
 	CompactStorage bool
 	// Compressor specifies the compressor (if any) to use on a newly created table
 	Compressor string
+	// Context allows a request context to passed, which is propagated to the QueryExecutor
+	Context context.Context
 }
 
-// Returns a new Options which is a right biased merge of the two initial Options.
+// Merge returns a new Options which is a right biased merge of the two initial Options.
 func (o Options) Merge(neu Options) Options {
 	ret := Options{
 		TTL:             o.TTL,
@@ -66,6 +69,7 @@ func (o Options) Merge(neu Options) Options {
 		Select:          o.Select,
 		CompactStorage:  o.CompactStorage,
 		Compressor:      o.Compressor,
+		Context:         o.Context,
 	}
 	if neu.TTL != time.Duration(0) {
 		ret.TTL = neu.TTL
@@ -94,6 +98,11 @@ func (o Options) Merge(neu Options) Options {
 	if len(neu.Compressor) > 0 {
 		ret.Compressor = neu.Compressor
 	}
+	// Take the latest context added, so it can be overridden
+	if neu.Context != nil {
+		ret.Context = neu.Context
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
Add a very basic way to propagate `context` by adding to the `Options` which means the interface is unchanged. This allows a user to propagate a context (ie a request context with a trace ID) through to the `QueryExecutor` which may be custom. 

Usage:

```
someTable.Read(id, result).WithOptions(Options{Context: ctx}).Run()
```

I've also bumped the cassandra version used in the tests, as this was no longer present on the download server 😐 