### PR TITLE
Iterate through the field map in sorted order 🐛

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.9
+  - 1.10.x
+  - 1.11.x
   - tip
 
 addons:
@@ -14,6 +15,6 @@ before_install:
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
   - java -version
   - sudo rm -rf /var/lib/cassandra/*
-  - wget http://www.us.apache.org/dist/cassandra/3.0.16/apache-cassandra-3.0.16-bin.tar.gz && tar -xvzf apache-cassandra-3.0.16-bin.tar.gz
+  - wget https://archive.apache.org/dist/cassandra/3.0.16/apache-cassandra-3.0.16-bin.tar.gz && tar -xvzf apache-cassandra-3.0.16-bin.tar.gz
   - sudo sh ./apache-cassandra-3.0.16/bin/cassandra -R
   - sleep 20

--- a/op.go
+++ b/op.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 
 	"github.com/mitchellh/mapstructure"
@@ -238,17 +239,17 @@ func updateStatement(kn, cfName string, fields map[string]interface{}, opts Opti
 	buf.WriteString("SET ")
 	i := 0
 	ret := []interface{}{}
-	for k, v := range fields {
+	for _, k := range sortedKeys(fields) {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		if mod, ok := v.(Modifier); ok {
+		if mod, ok := fields[k].(Modifier); ok {
 			stmt, vals := mod.cql(k)
 			buf.WriteString(stmt)
 			ret = append(ret, vals...)
 		} else {
 			buf.WriteString(k + " = ?")
-			ret = append(ret, v)
+			ret = append(ret, fields[k])
 		}
 		i++
 	}
@@ -298,4 +299,13 @@ func decodeBigIntHook(f reflect.Kind, t reflect.Kind, data interface{}) (interfa
 	}
 
 	return data, nil
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/op.go
+++ b/op.go
@@ -302,7 +302,7 @@ func decodeBigIntHook(f reflect.Kind, t reflect.Kind, data interface{}) (interfa
 }
 
 func sortedKeys(m map[string]interface{}) []string {
-	var keys []string
+	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}

--- a/table.go
+++ b/table.go
@@ -59,9 +59,9 @@ func (t *t) zero() interface{} {
 func keyValues(m map[string]interface{}) ([]string, []interface{}) {
 	keys := []string{}
 	values := []interface{}{}
-	for k, v := range m {
+	for _, k := range sortedKeys(m) {
 		keys = append(keys, k)
-		values = append(values, v)
+		values = append(values, m[k])
 	}
 	return keys, values
 }


### PR DESCRIPTION
I went on a 🐛 hunt this evening trying to determine why we're using so many Cassandra prepared statements. 

Currently, GoCassa is iterating over the fields of UPDATE/INSERT statement maps. This means we get a non-deterministic ordering of field names when the CQL statement is generated, resulting in the same gocassa operation yielding different generated statements. 

For example, the first time you might get
```
UPDATE test_keyspace.test_table SET val1 = ?, val2 = ?, val3 = ?
```
And a subsequent time you might get
```
UPDATE test_keyspace.test_table SET val2 = ?, val3 = ?, val1 = ?
```
and so on.

This PR fixes by iterating over the map in a deterministic order by field name.

Now you might ask how this relates to prepared statements. [GoCQL](http://github.com/monzo/gocql) uses prepared statements for pretty much all queries. Under the hood, Cassandra maintains a cache of queries (based on heap size). [Cassandra uses the hash of the query](https://docs.datastax.com/en/developer/java-driver/3.0/manual/statements/prepared/#preparing-on-multiple-nodes) and uses the raw query string as the cache identifier (and so does GoCQL on the client side along with the node address). As a kicker, prepared statements are propagated by the client on a node by node basis.

This change will give a speedup on both the Client and Cassandra, GoCQL will benefit because it drastically reduces the permutations it needs to propagate to 1 per table per node and Cassandra will benefit by not constantly thrashing the prepared statement cache.