### PR TITLE
Order field names to get consistent select statements 🐞

### DIFF
--- a/table.go
+++ b/table.go
@@ -35,11 +35,11 @@ func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSou
 		keys:          keys,
 		fieldSource:   fieldSource,
 	}
-	fields := []string{}
-	values := []interface{}{}
-	for k, v := range fieldSource {
+	fields := make([]string, 0, len(fieldSource))
+	values := make([]interface{}, 0, len(fieldSource))
+	for _, k := range sortedKeys(fieldSource) {
 		fields = append(fields, k)
-		values = append(values, v)
+		values = append(values, fieldSource[k])
 	}
 	cinf.fieldNames = map[string]struct{}{}
 	for _, v := range fields {


### PR DESCRIPTION
Along the lines of https://github.com/monzo/gocassa/pull/35, this PR modifies the order in which fields are stored to ensure they are sorted.

This list of fields is used to generate the `SELECT` statement in GoCassa. Since it's populated from a map, the ordering of field names is not consistent. 

This 🐛 was a bit more tricky to track down because the list of fields is set in stone when you define the GoCassa table. This means if you define the table as a constant, within one running instance of your program, you'll have consistent ordering of fields no matter how many times you run the query. However, across different instances of the same program, the ordering will be varied.

For example, `myapplication-abcd1` may be consistently requesting
```
SELECT field1, field2, field3, field4 FROM test_keyspace.test_table
```
Whereas `myapplication-efgh2` may be consistently requesting
```
SELECT field2, field4, field1, field3 FROM test_keyspace.test_table
```
(and so on for different permutations of fields based on number of running application replicas)

This again brings more problems/duplication onto the Cassandra Prepared Statement cache because you have different permutations of the same query with different ordering of column names being selected.