### PR TITLE
Ensure we bind the TTL within our statements 🕰

### DIFF
--- a/table.go
+++ b/table.go
@@ -133,13 +133,13 @@ func transformFields(m map[string]interface{}) {
 //   VALUES ('cfd66ccc-d857-4e90-b1e5-df98a3d40cd6', 'johndoe')
 //
 // Gotcha: primkey must be first
-func insertStatement(keySpaceName, cfName string, fieldNames []string, opts Options) string {
+func insertStatement(keySpaceName, cfName string, fields map[string]interface{}, opts Options) (string, []interface{}) {
+	fieldNames, vals := keyValues(fields)
+
 	placeHolders := make([]string, len(fieldNames))
-	for i := 0; i < len(fieldNames); i++ {
-		placeHolders[i] = "?"
-	}
 	lowerFieldNames := make([]string, len(fieldNames))
 	for i, v := range fieldNames {
+		placeHolders[i] = "?"
 		lowerFieldNames[i] = strings.ToLower(v)
 	}
 
@@ -152,11 +152,11 @@ func insertStatement(keySpaceName, cfName string, fieldNames []string, opts Opti
 
 	// Apply options
 	if opts.TTL != 0 {
-		buf.WriteString(" USING TTL ")
-		buf.WriteString(strconv.FormatFloat(opts.TTL.Seconds(), 'f', 0, 64))
+		buf.WriteString(" USING TTL ? ")
+		vals = append(vals, strconv.FormatFloat(opts.TTL.Seconds(), 'f', 0, 64))
 	}
 
-	return buf.String()
+	return buf.String(), vals
 }
 
 func (t t) Set(i interface{}) Op {


### PR DESCRIPTION
Right now, we're generating statements with the TTL not bound. For some of our services, we generated TTLs from now to a fixed point in the future. This means our prepared statement cache keeps growing as the TTLs change relative to time.

From Cassandra 2.0, [you can bind the TTL](https://groups.google.com/a/lists.datastax.com/forum/#!topic/java-driver-user/V5c6GCl-ovk) as an argument just like anything else, and thus we should.

With this PR, we go from doing:
```
UPDATE foospace.blah USING TTL 5122948 SET val1 = ?, val2 = ?, val3 = ?
INSERT INTO foospace.blah (val1, val2, val3) VALUES (?, ?, ?) USING TTL 5122948 
```
to
```
UPDATE foospace.blah USING TTL ? SET val1 = ?, val2 = ?, val3 = ?
INSERT INTO foospace.blah (val1, val2, val3) VALUES (?, ?, ?) USING TTL ? 
```