### PR TITLE
Add RunWithContext and RunAtomicallyWithContext

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -30,6 +30,7 @@ func (o errOp) RunWithContext(_ context.Context) error           { return o.err 
 func (o errOp) RunAtomicallyWithContext(_ context.Context) error { return o.err }
 func (o errOp) RunAtomically() error                             { return o.err }
 func (o errOp) Add(ops ...Op) Op                                 { return multiOp{o}.Add(ops...) }
+func (o errOp) Options() Options                                 { return Options{} }
 func (o errOp) WithOptions(_ Options) Op                         { return o }
 func (o errOp) Preflight() error                                 { return o.err }
 func (o errOp) GenerateStatement() (string, []interface{})       { return "", []interface{}{} }

--- a/errors.go
+++ b/errors.go
@@ -27,8 +27,8 @@ type errOp struct{ err error }
 
 func (o errOp) Run() error                                       { return o.err }
 func (o errOp) RunWithContext(_ context.Context) error           { return o.err }
-func (o errOp) RunAtomicallyWithContext(_ context.Context) error { return o.err }
 func (o errOp) RunAtomically() error                             { return o.err }
+func (o errOp) RunAtomicallyWithContext(_ context.Context) error { return o.err }
 func (o errOp) Add(ops ...Op) Op                                 { return multiOp{o}.Add(ops...) }
 func (o errOp) Options() Options                                 { return Options{} }
 func (o errOp) WithOptions(_ Options) Op                         { return o }

--- a/errors.go
+++ b/errors.go
@@ -25,11 +25,12 @@ func (r RowNotFoundError) Error() string {
 // in a multiOp scenario)
 type errOp struct{ err error }
 
-func (o errOp) Run() error                                 { return o.err }
-func (o errOp) RunWithContext(_ context.Context) error     { return o.err }
-func (o errOp) RunAtomically() error                       { return o.err }
-func (o errOp) Add(ops ...Op) Op                           { return multiOp{o}.Add(ops...) }
-func (o errOp) WithOptions(_ Options) Op                   { return o }
-func (o errOp) Preflight() error                           { return o.err }
-func (o errOp) GenerateStatement() (string, []interface{}) { return "", []interface{}{} }
-func (o errOp) QueryExecutor() QueryExecutor               { return nil }
+func (o errOp) Run() error                                       { return o.err }
+func (o errOp) RunWithContext(_ context.Context) error           { return o.err }
+func (o errOp) RunAtomicallyWithContext(_ context.Context) error { return o.err }
+func (o errOp) RunAtomically() error                             { return o.err }
+func (o errOp) Add(ops ...Op) Op                                 { return multiOp{o}.Add(ops...) }
+func (o errOp) WithOptions(_ Options) Op                         { return o }
+func (o errOp) Preflight() error                                 { return o.err }
+func (o errOp) GenerateStatement() (string, []interface{})       { return "", []interface{}{} }
+func (o errOp) QueryExecutor() QueryExecutor                     { return nil }

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -25,6 +26,7 @@ func (r RowNotFoundError) Error() string {
 type errOp struct{ err error }
 
 func (o errOp) Run() error                                 { return o.err }
+func (o errOp) RunWithContext(_ context.Context) error     { return o.err }
 func (o errOp) RunAtomically() error                       { return o.err }
 func (o errOp) Add(ops ...Op) Op                           { return multiOp{o}.Add(ops...) }
 func (o errOp) WithOptions(_ Options) Op                   { return o }

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -9,6 +9,10 @@ type goCQLBackend struct {
 	session *gocql.Session
 }
 
+func (cb goCQLBackend) Query(stmt string, vals ...interface{}) ([]map[string]interface{}, error) {
+	return cb.QueryWithOptions(Options{}, stmt, vals...)
+}
+
 func (cb goCQLBackend) QueryWithOptions(opts Options, stmt string, vals ...interface{}) ([]map[string]interface{}, error) {
 	qu := cb.session.Query(stmt, vals...)
 	if opts.Consistency != nil {
@@ -24,8 +28,8 @@ func (cb goCQLBackend) QueryWithOptions(opts Options, stmt string, vals ...inter
 	return ret, iter.Close()
 }
 
-func (cb goCQLBackend) Query(stmt string, vals ...interface{}) ([]map[string]interface{}, error) {
-	return cb.QueryWithOptions(Options{}, stmt, vals...)
+func (cb goCQLBackend) Execute(stmt string, vals ...interface{}) error {
+	return cb.ExecuteWithOptions(Options{}, stmt, vals...)
 }
 
 func (cb goCQLBackend) ExecuteWithOptions(opts Options, stmt string, vals ...interface{}) error {
@@ -36,8 +40,8 @@ func (cb goCQLBackend) ExecuteWithOptions(opts Options, stmt string, vals ...int
 	return qu.Exec()
 }
 
-func (cb goCQLBackend) Execute(stmt string, vals ...interface{}) error {
-	return cb.ExecuteWithOptions(Options{}, stmt, vals...)
+func (cb goCQLBackend) ExecuteAtomically(stmts []string, vals [][]interface{}) error {
+	return cb.ExecuteAtomicallyWithOptions(Options{}, stmts, vals)
 }
 
 func (cb goCQLBackend) ExecuteAtomicallyWithOptions(opts Options, stmts []string, vals [][]interface{}) error {
@@ -58,10 +62,6 @@ func (cb goCQLBackend) ExecuteAtomicallyWithOptions(opts Options, stmts []string
 	}
 
 	return cb.session.ExecuteBatch(batch)
-}
-
-func (cb goCQLBackend) ExecuteAtomically(stmts []string, vals [][]interface{}) error {
-	return cb.ExecuteAtomicallyWithOptions(Options{}, stmts, vals)
 }
 
 // GoCQLSessionToQueryExecutor enables you to supply your own gocql session with your custom options

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -1,8 +1,8 @@
 package gocassa
 
 import (
+	"context"
 	"errors"
-
 	"github.com/gocql/gocql"
 )
 
@@ -54,6 +54,10 @@ func (cb goCQLBackend) ExecuteAtomically(stmts []string, vals [][]interface{}) e
 		batch.Query(stmts[i], vals[i]...)
 	}
 	return cb.session.ExecuteBatch(batch)
+}
+
+func (cb goCQLBackend) ExecuteAtomicallyWithContext(_ context.Context, stmts []string, vals [][]interface{}) error {
+	return cb.ExecuteAtomically(stmts, vals)
 }
 
 // GoCQLSessionToQueryExecutor enables you to supply your own gocql session with your custom options

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"context"
 	"time"
 )
 
@@ -195,6 +196,8 @@ type Keys struct {
 type Op interface {
 	// Run the operation.
 	Run() error
+	// Run the operation, first running WithOptions with the provided context.
+	RunWithContext(context.Context) error
 	// You do not need this in 95% of the use cases, use Run!
 	// Using atomic batched writes (logged batches in Cassandra terminology) comes at a high performance cost!
 	RunAtomically() error

--- a/interfaces.go
+++ b/interfaces.go
@@ -196,7 +196,7 @@ type Keys struct {
 type Op interface {
 	// Run the operation.
 	Run() error
-	// Run the operation, first running WithOptions with the provided context.
+	// Run the operation, providing context to the executor.
 	RunWithContext(context.Context) error
 	// You do not need this in 95% of the use cases, use Run!
 	// Using atomic batched writes (logged batches in Cassandra terminology) comes at a high performance cost!

--- a/interfaces.go
+++ b/interfaces.go
@@ -201,6 +201,8 @@ type Op interface {
 	// You do not need this in 95% of the use cases, use Run!
 	// Using atomic batched writes (logged batches in Cassandra terminology) comes at a high performance cost!
 	RunAtomically() error
+	// Run the operation atomically, providing context to the executor.
+	RunAtomicallyWithContext(context.Context) error
 	// Add an other Op to this one.
 	Add(...Op) Op
 	// WithOptions lets you specify `Op` level `Options`.
@@ -266,7 +268,9 @@ type QueryExecutor interface {
 	ExecuteWithOptions(opts Options, stmt string, params ...interface{}) error
 	// Execute executes a DML query
 	Execute(stmt string, params ...interface{}) error
-	// ExecuteAtomically executs multiple DML queries with a logged batch
+	// ExecuteAtomically executes multiple DML queries with a logged batch, and takes context
+	ExecuteAtomicallyWithContext(ctx context.Context, stmt []string, params [][]interface{}) error
+	// ExecuteAtomically executes multiple DML queries with a logged batch
 	ExecuteAtomically(stmt []string, params [][]interface{}) error
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -215,6 +215,8 @@ type Op interface {
 	//    op1.WithOptions(Options{Limit:3}).Add(op2).WithOptions(Options{Limit:2}) // op1 and op2 both have a limit of 2
 	//
 	WithOptions(Options) Op
+	// Options lets you read the `Options` for this `Op`
+	Options() Options
 	// Preflight performs any pre-execution validation that confirms the op considers itself "valid".
 	// NOTE: Run() and RunAtomically() should call this method before execution, and abort if any errors are returned.
 	Preflight() error
@@ -269,7 +271,7 @@ type QueryExecutor interface {
 	// Execute executes a DML query
 	Execute(stmt string, params ...interface{}) error
 	// ExecuteAtomically executes multiple DML queries with a logged batch, and takes context
-	ExecuteAtomicallyWithContext(ctx context.Context, stmt []string, params [][]interface{}) error
+	ExecuteAtomicallyWithOptions(opts Options, stmt []string, params [][]interface{}) error
 	// ExecuteAtomically executes multiple DML queries with a logged batch
 	ExecuteAtomically(stmt []string, params [][]interface{}) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -201,7 +201,7 @@ type Op interface {
 	// You do not need this in 95% of the use cases, use Run!
 	// Using atomic batched writes (logged batches in Cassandra terminology) comes at a high performance cost!
 	RunAtomically() error
-	// Run the operation atomically, providing context to the executor.
+	// Run the operation as an atomic (logged) batch, providing context to the executor.
 	RunAtomicallyWithContext(context.Context) error
 	// Add an other Op to this one.
 	Add(...Op) Op
@@ -270,10 +270,10 @@ type QueryExecutor interface {
 	ExecuteWithOptions(opts Options, stmt string, params ...interface{}) error
 	// Execute executes a DML query
 	Execute(stmt string, params ...interface{}) error
-	// ExecuteAtomically executes multiple DML queries with a logged batch, and takes context
-	ExecuteAtomicallyWithOptions(opts Options, stmt []string, params [][]interface{}) error
 	// ExecuteAtomically executes multiple DML queries with a logged batch
 	ExecuteAtomically(stmt []string, params [][]interface{}) error
+	// ExecuteAtomically executes multiple DML queries with a logged batch, and takes options
+	ExecuteAtomicallyWithOptions(opts Options, stmt []string, params [][]interface{}) error
 }
 
 type Counter int

--- a/mock.go
+++ b/mock.go
@@ -47,6 +47,10 @@ func (m mockOp) RunWithContext(ctx context.Context) error {
 	return m.WithOptions(Options{Context: ctx}).Run()
 }
 
+func (m mockOp) Options() Options {
+	return m.options
+}
+
 func (m mockOp) WithOptions(opt Options) Op {
 	return mockOp{
 		options: opt,
@@ -122,6 +126,14 @@ func (mo mockMultiOp) Add(inOps ...Op) Op {
 		}
 	}
 	return append(mo, ops...)
+}
+
+func (mo mockMultiOp) Options() Options {
+	var opts Options
+	for _, op := range mo {
+		opts.Merge(op.Options())
+	}
+	return opts
 }
 
 func (mo mockMultiOp) WithOptions(opts Options) Op {

--- a/mock.go
+++ b/mock.go
@@ -54,6 +54,10 @@ func (m mockOp) WithOptions(opt Options) Op {
 	}
 }
 
+func (m mockOp) RunAtomicallyWithContext(_ context.Context) error {
+	return m.Run()
+}
+
 func (m mockOp) RunAtomically() error {
 	return m.Run()
 }
@@ -89,6 +93,10 @@ func (mo mockMultiOp) RunWithContext(ctx context.Context) error {
 }
 
 func (mo mockMultiOp) RunAtomically() error {
+	return mo.Run()
+}
+
+func (mo mockMultiOp) RunAtomicallyWithContext(_ context.Context) error {
 	return mo.Run()
 }
 

--- a/mock.go
+++ b/mock.go
@@ -58,12 +58,12 @@ func (m mockOp) WithOptions(opt Options) Op {
 	}
 }
 
-func (m mockOp) RunAtomicallyWithContext(_ context.Context) error {
+func (m mockOp) RunAtomically() error {
 	return m.Run()
 }
 
-func (m mockOp) RunAtomically() error {
-	return m.Run()
+func (m mockOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return m.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (m mockOp) GenerateStatement() (string, []interface{}) {
@@ -100,8 +100,8 @@ func (mo mockMultiOp) RunAtomically() error {
 	return mo.Run()
 }
 
-func (mo mockMultiOp) RunAtomicallyWithContext(_ context.Context) error {
-	return mo.Run()
+func (mo mockMultiOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return mo.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (mo mockMultiOp) GenerateStatement() (string, []interface{}) {

--- a/mock.go
+++ b/mock.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sync"
 
+	"context"
 	"github.com/gocql/gocql"
 	"github.com/google/btree"
 )
@@ -40,6 +41,10 @@ func (m mockOp) Run() error {
 		}
 	}
 	return nil
+}
+
+func (m mockOp) RunWithContext(ctx context.Context) error {
+	return m.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (m mockOp) WithOptions(opt Options) Op {
@@ -77,6 +82,10 @@ func (mo mockMultiOp) Run() error {
 		}
 	}
 	return nil
+}
+
+func (mo mockMultiOp) RunWithContext(ctx context.Context) error {
+	return mo.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (mo mockMultiOp) RunAtomically() error {

--- a/mock_test.go
+++ b/mock_test.go
@@ -18,8 +18,8 @@ type user struct {
 }
 
 type UserWithMap struct {
-	Id  string
-	Map map[string]interface{}
+	Id       string
+	Map      map[string]interface{}
 	OtherMap map[int]interface{}
 }
 
@@ -222,13 +222,13 @@ func (s *MockSuite) TestMapModifiers() {
 
 	// MapSetField
 	if err := tbl.Update("1", map[string]interface{}{
-		"OtherMap": MapSetField(1,  "One"),
+		"OtherMap": MapSetField(1, "One"),
 	}).Run(); err != nil {
 		s.T().Fatal(err)
 	}
 
 	if err := tbl.Update("1", map[string]interface{}{
-		"OtherMap": MapSetField(2,  "Two"),
+		"OtherMap": MapSetField(2, "Two"),
 	}).Run(); err != nil {
 		s.T().Fatal(err)
 	}

--- a/multiop.go
+++ b/multiop.go
@@ -25,10 +25,6 @@ func (mo multiOp) RunWithContext(ctx context.Context) error {
 }
 
 func (mo multiOp) RunAtomically() error {
-	return mo.RunAtomicallyWithContext(nil)
-}
-
-func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
 	if len(mo) == 0 {
 		return nil
 	}
@@ -46,11 +42,11 @@ func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
 		vals[i] = v
 	}
 
-	if ctx == nil {
-		return qe.ExecuteAtomically(stmts, vals)
-	}
+	return qe.ExecuteAtomicallyWithOptions(mo.Options(), stmts, vals)
+}
 
-	return qe.ExecuteAtomicallyWithContext(ctx, stmts, vals)
+func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return mo.WithOptions(Options{Context: ctx}).RunAtomically()
 }
 
 func (mo multiOp) GenerateStatement() (string, []interface{}) {
@@ -86,6 +82,14 @@ func (mo multiOp) Add(ops_ ...Op) Op {
 		}
 	}
 	return mo
+}
+
+func (mo multiOp) Options() Options {
+	var opts Options
+	for _, op := range mo {
+		opts.Merge(op.Options())
+	}
+	return opts
 }
 
 func (mo multiOp) WithOptions(opts Options) Op {

--- a/multiop.go
+++ b/multiop.go
@@ -1,5 +1,7 @@
 package gocassa
 
+import "context"
+
 type multiOp []Op
 
 func Noop() Op {
@@ -16,6 +18,10 @@ func (mo multiOp) Run() error {
 		}
 	}
 	return nil
+}
+
+func (mo multiOp) RunWithContext(ctx context.Context) error {
+	return mo.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (mo multiOp) RunAtomically() error {

--- a/multiop.go
+++ b/multiop.go
@@ -25,6 +25,10 @@ func (mo multiOp) RunWithContext(ctx context.Context) error {
 }
 
 func (mo multiOp) RunAtomically() error {
+	return mo.RunAtomicallyWithContext(nil)
+}
+
+func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
 	if len(mo) == 0 {
 		return nil
 	}
@@ -42,7 +46,11 @@ func (mo multiOp) RunAtomically() error {
 		vals[i] = v
 	}
 
-	return qe.ExecuteAtomically(stmts, vals)
+	if ctx == nil {
+		return qe.ExecuteAtomically(stmts, vals)
+	}
+
+	return qe.ExecuteAtomicallyWithContext(ctx, stmts, vals)
 }
 
 func (mo multiOp) GenerateStatement() (string, []interface{}) {

--- a/op.go
+++ b/op.go
@@ -104,6 +104,10 @@ func (o *singleOp) Run() error {
 	return nil
 }
 
+func (o *singleOp) RunAtomicallyWithContext(_ context.Context) error {
+	return o.Run()
+}
+
 func (o *singleOp) RunAtomically() error {
 	return o.Run()
 }

--- a/op.go
+++ b/op.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 
+	"context"
 	"github.com/mitchellh/mapstructure"
 	rreflect "github.com/monzo/gocassa/reflect"
 )
@@ -85,6 +86,10 @@ func (w *singleOp) readOne() error {
 func (w *singleOp) write() error {
 	stmt, params := w.generateWrite(w.options)
 	return w.qe.ExecuteWithOptions(w.options, stmt, params...)
+}
+
+func (o *singleOp) RunWithContext(ctx context.Context) error {
+	return o.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (o *singleOp) Run() error {

--- a/op.go
+++ b/op.go
@@ -108,12 +108,12 @@ func (o *singleOp) Run() error {
 	return nil
 }
 
-func (o *singleOp) RunAtomicallyWithContext(_ context.Context) error {
+func (o *singleOp) RunAtomically() error {
 	return o.Run()
 }
 
-func (o *singleOp) RunAtomically() error {
-	return o.Run()
+func (o *singleOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return o.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (o *singleOp) GenerateStatement() (string, []interface{}) {

--- a/op.go
+++ b/op.go
@@ -92,10 +92,6 @@ func (w *singleOp) write() error {
 	return w.qe.ExecuteWithOptions(w.options, stmt, params...)
 }
 
-func (o *singleOp) RunWithContext(ctx context.Context) error {
-	return o.WithOptions(Options{Context: ctx}).Run()
-}
-
 func (o *singleOp) Run() error {
 	switch o.opType {
 	case updateOpType, insertOpType, deleteOpType:
@@ -106,6 +102,10 @@ func (o *singleOp) Run() error {
 		return o.readOne()
 	}
 	return nil
+}
+
+func (o *singleOp) RunWithContext(ctx context.Context) error {
+	return o.WithOptions(Options{Context: ctx}).Run()
 }
 
 func (o *singleOp) RunAtomically() error {

--- a/op.go
+++ b/op.go
@@ -31,6 +31,10 @@ type singleOp struct {
 	qe      QueryExecutor
 }
 
+func (o *singleOp) Options() Options {
+	return o.options
+}
+
 func (o *singleOp) WithOptions(opts Options) Op {
 	return &singleOp{
 		options: o.options.Merge(opts),

--- a/table_test.go
+++ b/table_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/gocql/gocql"
 )
 
@@ -293,6 +294,10 @@ func (qe OptionCheckingQE) Execute(stmt string, params ...interface{}) error {
 }
 
 func (qe OptionCheckingQE) ExecuteAtomically(stmt []string, params [][]interface{}) error {
+	return nil
+}
+
+func (qe OptionCheckingQE) ExecuteAtomicallyWithContext(ctx context.Context, stmt []string, params [][]interface{}) error {
 	return nil
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"context"
 	"github.com/gocql/gocql"
 )
 
@@ -297,7 +296,8 @@ func (qe OptionCheckingQE) ExecuteAtomically(stmt []string, params [][]interface
 	return nil
 }
 
-func (qe OptionCheckingQE) ExecuteAtomicallyWithContext(ctx context.Context, stmt []string, params [][]interface{}) error {
+func (qe OptionCheckingQE) ExecuteAtomicallyWithOptions(opts Options, stmt []string, params [][]interface{}) error {
+	qe.opts.Consistency = opts.Consistency
 	return nil
 }
 


### PR DESCRIPTION
We need to start encouraging the passing of context to gocassa functions wherever possible - this will allow us to use jaeger tracing to track what we're sending to cassandra and how long it takes. Adding this sugar will hopefully make this easier for engineers to change their habits.