### PR TITLE
make sure that mock returns an error for an empty primary key

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -275,7 +275,7 @@ func (t *MockTable) zero() interface{} {
 	return reflect.New(reflect.TypeOf(t.entity)).Interface()
 }
 
-func (t *MockTable) keyFromColumnValues(values map[string]interface{}, keyNames []string) (key, error) {
+func (t *MockTable) partitionKeyFromColumnValues(values map[string]interface{}, keyNames []string) (key, error) {
 	var key key
 
 	for _, keyName := range keyNames {
@@ -284,6 +284,20 @@ func (t *MockTable) keyFromColumnValues(values map[string]interface{}, keyNames 
 		// write an empty string in the primary key
 		stringVal, isString := value.(string)
 		if !ok || (isString && stringVal == "") {
+			return nil, fmt.Errorf("Missing mandatory PRIMARY KEY part %s", keyName)
+		}
+		key = key.Append(keyName, value)
+	}
+
+	return key, nil
+}
+
+func (t *MockTable) clusteringKeyFromColumnValues(values map[string]interface{}, keyNames []string) (key, error) {
+	var key key
+
+	for _, keyName := range keyNames {
+		value, ok := values[keyName]
+		if !ok {
 			return nil, fmt.Errorf("Missing mandatory PRIMARY KEY part %s", keyName)
 		}
 		key = key.Append(keyName, value)
@@ -333,12 +347,12 @@ func (t *MockTable) SetWithOptions(i interface{}, options Options) Op {
 			return errors.New("Can't create: value not understood")
 		}
 
-		rowKey, err := t.keyFromColumnValues(columns, t.keys.PartitionKeys)
+		rowKey, err := t.partitionKeyFromColumnValues(columns, t.keys.PartitionKeys)
 		if err != nil {
 			return err
 		}
 
-		superColumnKey, err := t.keyFromColumnValues(columns, t.keys.ClusteringColumns)
+		superColumnKey, err := t.clusteringKeyFromColumnValues(columns, t.keys.ClusteringColumns)
 		if err != nil {
 			return err
 		}

--- a/mock.go
+++ b/mock.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"context"
+
 	"github.com/gocql/gocql"
 	"github.com/google/btree"
 )
@@ -279,8 +280,10 @@ func (t *MockTable) keyFromColumnValues(values map[string]interface{}, keyNames 
 
 	for _, keyName := range keyNames {
 		value, ok := values[keyName]
-
-		if !ok {
+		// need to explcitly check for string type here, as we cannot
+		// write an empty string in the primary key
+		stringVal, isString := value.(string)
+		if !ok || (isString && stringVal == "") {
 			return nil, fmt.Errorf("Missing mandatory PRIMARY KEY part %s", keyName)
 		}
 		key = key.Append(keyName, value)

--- a/mock_test.go
+++ b/mock_test.go
@@ -36,6 +36,7 @@ type PostalCode string
 type address struct {
 	Time            time.Time
 	Id              string
+	County          string
 	LocationPrice   map[string]int       // json compatible map
 	LocationHistory map[time.Time]string // not json compatible map
 	PostCode        PostalCode           // embedded type
@@ -48,15 +49,16 @@ func TestRunMockSuite(t *testing.T) {
 type MockSuite struct {
 	suite.Suite
 	*require.Assertions
-	tbl       Table
-	ks        KeySpace
-	mapTbl    MapTable
-	mmapTbl   MultimapTable
-	tsTbl     TimeSeriesTable
-	mtsTbl    MultiTimeSeriesTable
-	mkTsTbl   MultiKeyTimeSeriesTable
-	embMapTbl MapTable
-	embTsTbl  TimeSeriesTable
+	tbl                  Table
+	ks                   KeySpace
+	mapTbl               MapTable
+	mmapTbl              MultimapTable
+	tsTbl                TimeSeriesTable
+	mtsTbl               MultiTimeSeriesTable
+	mkTsTbl              MultiKeyTimeSeriesTable
+	embMapTbl            MapTable
+	embTsTbl             TimeSeriesTable
+	addressByCountyMmTbl MultimapTable
 }
 
 func (s *MockSuite) SetupTest() {
@@ -75,6 +77,7 @@ func (s *MockSuite) SetupTest() {
 
 	s.embMapTbl = s.ks.MapTable("addresses", "Id", address{})
 	s.embTsTbl = s.ks.TimeSeriesTable("addresses", "Time", "Id", 1*time.Minute, address{})
+	s.addressByCountyMmTbl = s.ks.MultimapTable("address_by_county", "County", "Id", address{})
 }
 
 // Table tests
@@ -89,14 +92,29 @@ func (s *MockSuite) TestTableEmpty() {
 func (s *MockSuite) TestEmptyPrimaryKey() {
 	address := address{
 		Id:              "",
+		County:          "",
 		Time:            s.parseTime("2015-01-01 00:00:00"),
 		LocationPrice:   map[string]int{"A": 1},
 		LocationHistory: map[time.Time]string{time.Now().UTC(): "A"},
 		PostCode:        "ABC",
 	}
 
+	// embMapTbl has Id in the partition key
 	s.Error(s.embMapTbl.Set(address).Run())
-	s.Error(s.embTsTbl.Set(address).Run())
+	// addressByCountyMmTbl has County in the partition key
+	s.Error(s.addressByCountyMmTbl.Set(address).Run())
+
+	address.County = "London"
+	s.Error(s.embMapTbl.Set(address).Run())
+	// address can be written successfully, now that the partiton key -
+	// County is not empty anymore; Id is still empty
+	s.NoError(s.addressByCountyMmTbl.Set(address).Run())
+
+	address.Id = "someID"
+	// both Id and County are not empty, writing to the tables should be
+	// suucessful
+	s.NoError(s.embMapTbl.Set(address).Run())
+	s.NoError(s.addressByCountyMmTbl.Set(address).Run())
 }
 
 func (s *MockSuite) TestTableRead() {

--- a/mock_test.go
+++ b/mock_test.go
@@ -84,6 +84,21 @@ func (s *MockSuite) TestTableEmpty() {
 	s.Equal(0, len(result))
 }
 
+// TestEmptyPrimaryKey asserts that gocassa mock will return an error for a row
+// with an empty primary
+func (s *MockSuite) TestEmptyPrimaryKey() {
+	address := address{
+		Id:              "",
+		Time:            s.parseTime("2015-01-01 00:00:00"),
+		LocationPrice:   map[string]int{"A": 1},
+		LocationHistory: map[time.Time]string{time.Now().UTC(): "A"},
+		PostCode:        "ABC",
+	}
+
+	s.Error(s.embMapTbl.Set(address).Run())
+	s.Error(s.embTsTbl.Set(address).Run())
+}
+
 func (s *MockSuite) TestTableRead() {
 	u1, u2, u3, u4 := s.insertUsers()
 


### PR DESCRIPTION
Currently, we only check whether or not the key is present, we also need
to check if the value is an empty string. As far as I understand, it is
safe to write zero values for other types like int, time etc. in the
primary key, and writes only fail for empty strings.

This is a hack, and I couldn't figure out any other way of solving this.

I really wanted to fix this because real C* behavior would be to return
an error here, while unit tests with mocked keyspaces would happily
pass.