### PR TITLE
Merge existing options when mocking WithOptions

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -54,7 +54,7 @@ func (m mockOp) Options() Options {
 
 func (m mockOp) WithOptions(opt Options) Op {
 	return mockOp{
-		options: opt,
+		options: m.options.Merge(opt),
 		funcs:   m.funcs,
 	}
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -404,6 +405,23 @@ func (s *MockSuite) TestTimeSeriesTableList() {
 	s.Len(ps, 2)
 	s.Equal(points[1], ps[0])
 	s.Equal(points[2], ps[1])
+}
+
+func (s *MockSuite) TestWithOptions() {
+	points := s.insertPoints()
+	var ps []point
+
+	// First two points, but with a limit of one
+	s.NoError(s.tsTbl.List(points[0].Time, points[1].Time, &ps).
+		WithOptions(Options{Limit: 1}).Run())
+	s.Len(ps, 1)
+	s.Equal(points[0], ps[0])
+
+	// First two points, but with a limit of one, but RunWithContext
+	s.NoError(s.tsTbl.List(points[0].Time, points[1].Time, &ps).
+		WithOptions(Options{Limit: 1}).RunWithContext(context.Background()))
+	s.Len(ps, 1)
+	s.Equal(points[0], ps[0])
 }
 
 func (s *MockSuite) TestTimeSeriesTableUpdate() {


### PR DESCRIPTION
The behaviour with `Op`'s in normal usage is to merge any `Options` specified
in `WithOptions` with the `Op`'s existing `Options`. This was not being
followed in `mockOp`. This commit fixes this by making sure we always merge
with any existing `Options`, thus preventing the mocked `WithOptions`
unsetting any `Options` already set.

This commit also adds a test case to cover this.