### PR TITLE
Use custom reflection for decoding structs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v2.0.0 - 2019-06-11
+
+### Changed
+ - QueryExecutor now returns statements as a Statement interface object rather than a raw string
+
 ## v1.2.0 - 2015-12-22
 
 ### Added
  - Implemented `ORDER BY` for read queries
 
 ### Changed
-- Updated mock tables to use new method of decoding, now also supports embedded and non-key map types.
+ - Updated mock tables to use new method of decoding, now also supports embedded and non-key map types.
 
 ## v1.1.0 - 2015-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## v2.0.0 - 2019-06-11
+## v2.0.0 - 2019-06-22
+
+*Note*: This is a major version change and quite a lot of the internals have changed to make decoding substantially faster. You will need to make some tweaks to your code if you are upgrading from v1. Please see the updated `interfaces.go` and the example in `gocql_backend.go` for updated usage.
 
 ### Changed
  - QueryExecutor now returns statements as a Statement interface object rather than a raw string
+ - MapStructure has been completely removed as a dependency. Gocassa now does custom reflection coordinated with gocql
+ - The use of the QueryExecutor has changed completely. See `gocql_backend.go` for an updated example.
+ - Public interfaces now use Statement objects rather than just plain strings and values for queries
+ - Using the scanner will also encapsulate decoding the objects into your structs (previously this happened after the QueryExeuctor returned on `Query` and `QueryWithOptions` function calls)
 
 ## v1.2.0 - 2015-12-22
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gocassa
 
 Gocassa is a high-level library on top of [gocql](https://github.com/gocql/gocql).
 
-Current version: v1.2.0
+Current version: v2.0.0
 
 Compared to gocql it provides query building, adds data binding, and provides easy-to-use "recipe" tables for common query use-cases. Unlike [cqlc](https://github.com/relops/cqlc), it does not use code generation.
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,177 @@
+package gocassa
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+type blogPost struct {
+	PostID      string
+	AuthorName  string
+	Title       string
+	Tags        []string
+	Body        []byte
+	CreatedAt   time.Time
+	PublishedAt time.Time
+	IsPublished bool
+}
+
+func BenchmarkDecodeBlogSliceNoBody(b *testing.B) {
+	createdAt, _ := time.Parse("2006-01-02 15:04:05-0700", "2018-11-13 14:05:36+0000")
+	publishedAt, _ := time.Parse("2006-01-02 15:04:05-0700", "2018-11-13 14:05:36+0000")
+
+	m := map[string]interface{}{
+		"postid":      "post_000000001234",
+		"authorname":  "Jane Doe",
+		"title":       "gocassa",
+		"tags":        []string{"cassandra", "golang"},
+		"createdat":   createdAt,
+		"publishedAt": publishedAt,
+		"ispublished": true,
+	}
+
+	fieldNames := sortedKeys(m)
+	results := make([]map[string]interface{}, 20)
+	for i := 0; i < 20; i++ {
+		results[i] = m
+	}
+	stmt := newSelectStatement("", []interface{}{}, fieldNames)
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	for i := 0; i < b.N; i++ {
+		res := []blogPost{}
+		iter.Reset()
+		_, err := newScanner(stmt, &res).ScanIter(iter)
+
+		if err != nil {
+			b.Fatalf("err: %+v", err)
+		}
+
+		if len(res) != 20 {
+			b.Fatalf("expected 20 blog posts, got %d", len(res))
+		}
+
+		if res[0].Title != "gocassa" {
+			b.Fatalf("did not code result correctly, got %+v", res)
+		}
+	}
+}
+
+func BenchmarkDecodeBlogStruct(b *testing.B) {
+	postData, _ := ioutil.ReadFile("README.md") // this is a riveting read!
+	benchmarkBlogPostSingle(b, postData)
+}
+
+func BenchmarkDecodeBlogStructEmptyBody(b *testing.B) {
+	benchmarkBlogPostSingle(b, []byte{})
+}
+
+func benchmarkBlogPostSingle(b *testing.B, postData []byte) {
+	createdAt, _ := time.Parse("2006-01-02 15:04:05-0700", "2018-11-13 14:05:36+0000")
+	publishedAt, _ := time.Parse("2006-01-02 15:04:05-0700", "2018-11-13 14:05:36+0000")
+
+	m := map[string]interface{}{
+		"postid":      "post_000000001234",
+		"authorname":  "Jane Doe",
+		"title":       "gocassa",
+		"tags":        []string{"cassandra", "golang"},
+		"body":        postData,
+		"createdat":   createdAt,
+		"publishedAt": publishedAt,
+		"ispublished": true,
+	}
+
+	fieldNames := sortedKeys(m)
+	results := []map[string]interface{}{m}
+	stmt := newSelectStatement("", []interface{}{}, fieldNames)
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	for i := 0; i < b.N; i++ {
+		res := blogPost{}
+		iter.Reset()
+		_, err := newScanner(stmt, &res).ScanIter(iter)
+
+		if err != nil {
+			b.Fatalf("err: %+v", err)
+		}
+
+		if res.Title != "gocassa" {
+			b.Fatalf("did not code result correctly, got %+v", res)
+		}
+
+		if len(res.Body) != len(postData) {
+			b.Fatalf("did not code result correctly, got %+v", res)
+		}
+	}
+}
+
+type alphaStruct struct {
+	A, B, C, D, E, F, G string
+	H, I, J, K, L, M, N int
+	O, P, Q, R, S, T, U float32
+	V, W, X, Y, Z       float64
+}
+
+func BenchmarkDecodeAlphaSlice(b *testing.B) {
+	m := map[string]interface{}{
+		"a": "65", "b": "66", "c": "67", "d": "68", "e": "69", "f": "70", "g": "71",
+		"h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78,
+		"o": 79.0, "p": 80.0, "q": 81.0, "r": 82.0, "s": 83.0, "t": 84.0, "u": 85.0,
+		"v": 86.0, "w": 87.0, "x": 88.0, "y": 89.0, "z": 90.0,
+	}
+
+	fieldNames := sortedKeys(m)
+	results := make([]map[string]interface{}, 20)
+	for i := 0; i < 20; i++ {
+		results[i] = m
+	}
+	stmt := newSelectStatement("", []interface{}{}, fieldNames)
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	for i := 0; i < b.N; i++ {
+		res := []alphaStruct{}
+		iter.Reset()
+		_, err := newScanner(stmt, &res).ScanIter(iter)
+
+		if err != nil {
+			b.Fatalf("err: %+v", err)
+		}
+
+		if len(res) != 20 {
+			b.Fatalf("expected 20 alpha results, got %d", len(res))
+		}
+
+		if res[0].A != "65" || res[0].H != 72 || res[0].O != float32(79) || res[0].V != float64(86) {
+			b.Fatalf("did not code result correctly, got %+v", res)
+		}
+	}
+}
+
+func BenchmarkDecodeAlphaStruct(b *testing.B) {
+	m := map[string]interface{}{
+		"a": "65", "b": "66", "c": "67", "d": "68", "e": "69", "f": "70", "g": "71",
+		"h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78,
+		"o": 79.0, "p": 80.0, "q": 81.0, "r": 82.0, "s": 83.0, "t": 84.0, "u": 85.0,
+		"v": 86.0, "w": 87.0, "x": 88.0, "y": 89.0, "z": 90.0,
+	}
+
+	fieldNames := sortedKeys(m)
+	results := []map[string]interface{}{m}
+	stmt := newSelectStatement("", []interface{}{}, fieldNames)
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	for i := 0; i < b.N; i++ {
+		res := alphaStruct{}
+		iter.Reset()
+		_, err := newScanner(stmt, &res).ScanIter(iter)
+
+		if err != nil {
+			b.Fatalf("err: %+v", err)
+		}
+
+		if res.A != "65" || res.H != 72 || res.O != float32(79) || res.V != float64(86) {
+			b.Fatalf("did not code result correctly, got %+v", res)
+		}
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -31,13 +31,15 @@ func NewConnection(q QueryExecutor) Connection {
 
 // CreateKeySpace creates a keyspace with the given name. Only used to create test keyspaces.
 func (c *connection) CreateKeySpace(name string) error {
-	stmt := fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };", name)
+	query := fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };", name)
+	stmt := newStatement(query, []interface{}{})
 	return c.q.Execute(stmt)
 }
 
 // DropKeySpace drops the keyspace having the given name.
 func (c *connection) DropKeySpace(name string) error {
-	stmt := fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", name)
+	query := fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", name)
+	stmt := newStatement(query, []interface{}{})
 	return c.q.Execute(stmt)
 }
 

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package gocassa is a high-level library on top of gocql
 //
-// Current version: v1.2.0
+// Current version: v2.0.0
 // Compared to gocql it provides query building, adds data binding, and provides
 // easy-to-use "recipe" tables for common query use-cases. Unlike cqlc, it does
 // not use code generation.

--- a/errors.go
+++ b/errors.go
@@ -33,5 +33,5 @@ func (o errOp) Add(ops ...Op) Op                                 { return multiO
 func (o errOp) Options() Options                                 { return Options{} }
 func (o errOp) WithOptions(_ Options) Op                         { return o }
 func (o errOp) Preflight() error                                 { return o.err }
-func (o errOp) GenerateStatement() (string, []interface{})       { return "", []interface{}{} }
+func (o errOp) GenerateStatement() Statement                     { return noOpStatement }
 func (o errOp) QueryExecutor() QueryExecutor                     { return nil }

--- a/flakeseries_table.go
+++ b/flakeseries_table.go
@@ -21,13 +21,13 @@ type flakeSeriesT struct {
 	bucketSize time.Duration
 }
 
-func (o *flakeSeriesT) Table() Table                     { return o.t }
-func (o *flakeSeriesT) Create() error                    { return o.Table().Create() }
-func (o *flakeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
-func (o *flakeSeriesT) Name() string                     { return o.Table().Name() }
-func (o *flakeSeriesT) Recreate() error                  { return o.Table().Recreate() }
-func (o *flakeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
-func (o *flakeSeriesT) CreateIfNotExistStatement() (string, error) {
+func (o *flakeSeriesT) Table() Table                        { return o.t }
+func (o *flakeSeriesT) Create() error                       { return o.Table().Create() }
+func (o *flakeSeriesT) CreateIfNotExist() error             { return o.Table().CreateIfNotExist() }
+func (o *flakeSeriesT) Name() string                        { return o.Table().Name() }
+func (o *flakeSeriesT) Recreate() error                     { return o.Table().Recreate() }
+func (o *flakeSeriesT) CreateStatement() (Statement, error) { return o.Table().CreateStatement() }
+func (o *flakeSeriesT) CreateIfNotExistStatement() (Statement, error) {
 	return o.Table().CreateIfNotExistStatement()
 }
 

--- a/generate.go
+++ b/generate.go
@@ -28,21 +28,21 @@ import (
 // );
 //
 
-func createTableIfNotExist(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (string, error) {
+func createTableIfNotExist(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (Statement, error) {
 	return createTableStmt("CREATE TABLE IF NOT EXISTS", keySpace, cf, partitionKeys, colKeys, fields, values, order, compoundKey, compact, compressor)
 }
 
-func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (string, error) {
+func createTable(keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (Statement, error) {
 	return createTableStmt("CREATE TABLE", keySpace, cf, partitionKeys, colKeys, fields, values, order, compoundKey, compact, compressor)
 }
 
-func createTableStmt(createStmt, keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (string, error) {
+func createTableStmt(createStmt, keySpace, cf string, partitionKeys, colKeys []string, fields []string, values []interface{}, order []ClusteringOrderColumn, compoundKey, compact bool, compressor string) (Statement, error) {
 	firstLine := fmt.Sprintf("%s %v.%v (", createStmt, keySpace, cf)
 	fieldLines := []string{}
 	for i, _ := range fields {
 		typeStr, err := stringTypeOf(values[i])
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		l := "    " + strings.ToLower(fields[i]) + " " + typeStr
 		fieldLines = append(fieldLines, l)
@@ -93,8 +93,8 @@ func createTableStmt(createStmt, keySpace, cf string, partitionKeys, colKeys []s
 	}
 
 	lines = append(lines, ";")
-	stmt := strings.Join(lines, "\n")
-	return stmt, nil
+	qry := strings.Join(lines, "\n")
+	return newStatement(qry, []interface{}{}), nil
 }
 
 func j(s []string) string {

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -19,14 +19,12 @@ func (cb goCQLBackend) QueryWithOptions(opts Options, stmt Statement, scanner Sc
 	}
 
 	iter := qu.Iter()
-	_, err := scanner.ScanIter(iter)
-	errClose := iter.Close()
-
-	if err != nil {
+	if _, err := scanner.ScanIter(iter); err != nil {
+		iter.Close() // try and close the iterator to release any resources
 		return err
 	}
 
-	return errClose
+	return iter.Close()
 }
 
 func (cb goCQLBackend) Execute(stmt Statement) error {

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -19,7 +19,7 @@ func (cb goCQLBackend) QueryWithOptions(opts Options, stmt Statement, scanner Sc
 	}
 
 	iter := qu.Iter()
-	_, err := scanner.ScanAll(iter)
+	_, err := scanner.ScanIter(iter)
 	errClose := iter.Close()
 
 	if err != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -2,6 +2,7 @@ package gocassa
 
 import (
 	"context"
+	"reflect"
 	"time"
 )
 
@@ -262,9 +263,13 @@ type Table interface {
 // Statement encapsulates a gocassa generated statement to be passed via
 // the QueryExecutor.
 type Statement interface {
-	// ColumnNames contains the column names which will be selected
+	// FieldNames contains the column names which will be selected
 	// This will only be populated for SELECT queries
-	ColumnNames() []string
+	FieldNames() []string
+	// FieldTypes contains the binding types of columns selected
+	// in their referenced struct. This will only be populated for
+	// SELECT queries
+	FieldTypes() []reflect.Type
 	// Values encapsulates binding values to be set within the CQL
 	// query string as binding parameters. If there are no binding
 	// parameters in the query, this will be the empty slice

--- a/interfaces.go
+++ b/interfaces.go
@@ -277,10 +277,10 @@ type Scannable interface {
 
 // Scanner encapsulates a scanner which scans rows from a GoCQL iterator.
 type Scanner interface {
-	// ScanAll takes in a Scannale iterator found in GoCQL and scans until
+	// ScanIter takes in a Scannale iterator found in GoCQL and scans until
 	// the iterator giveth no more. It number of rows read and an optional
 	// error if anything goes wrong
-	ScanAll(iter Scannable) (int, error)
+	ScanIter(iter Scannable) (int, error)
 }
 
 // QueryExecutor actually executes the queries - this is mostly useful for testing/mocking purposes,

--- a/keyspace.go
+++ b/keyspace.go
@@ -197,13 +197,14 @@ func (k *k) MultiFlakeSeriesTable(name, indexField, idField string, bucketSize t
 
 // Returns table names in a keyspace
 func (k *k) Tables() ([]string, error) {
-	const stmt = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?"
+	const query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?"
 
 	if k.qe == nil {
 		return nil, fmt.Errorf("no query executor configured")
 	}
 
-	maps, err := k.qe.Query(stmt, k.name)
+	stmt := newStatement(query, []interface{}{k.name})
+	maps, err := k.qe.Query(stmt)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +229,8 @@ func (k *k) Exists(cf string) (bool, error) {
 }
 
 func (k *k) DropTable(cf string) error {
-	stmt := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", k.name, cf)
+	query := fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", k.name, cf)
+	stmt := newStatement(query, []interface{}{})
 	return k.qe.Execute(stmt)
 }
 

--- a/map_table.go
+++ b/map_table.go
@@ -5,13 +5,13 @@ type mapT struct {
 	idField string
 }
 
-func (m *mapT) Table() Table                     { return m.t }
-func (m *mapT) Create() error                    { return m.Table().Create() }
-func (m *mapT) CreateIfNotExist() error          { return m.Table().CreateIfNotExist() }
-func (m *mapT) Name() string                     { return m.Table().Name() }
-func (m *mapT) Recreate() error                  { return m.Table().Recreate() }
-func (m *mapT) CreateStatement() (string, error) { return m.Table().CreateStatement() }
-func (m *mapT) CreateIfNotExistStatement() (string, error) {
+func (m *mapT) Table() Table                        { return m.t }
+func (m *mapT) Create() error                       { return m.Table().Create() }
+func (m *mapT) CreateIfNotExist() error             { return m.Table().CreateIfNotExist() }
+func (m *mapT) Name() string                        { return m.Table().Name() }
+func (m *mapT) Recreate() error                     { return m.Table().Recreate() }
+func (m *mapT) CreateStatement() (Statement, error) { return m.Table().CreateStatement() }
+func (m *mapT) CreateIfNotExistStatement() (Statement, error) {
 	return m.Table().CreateIfNotExistStatement()
 }
 

--- a/mock.go
+++ b/mock.go
@@ -67,8 +67,8 @@ func (m mockOp) RunAtomicallyWithContext(ctx context.Context) error {
 	return m.WithOptions(Options{Context: ctx}).Run()
 }
 
-func (m mockOp) GenerateStatement() (string, []interface{}) {
-	return "", []interface{}{}
+func (m mockOp) GenerateStatement() Statement {
+	return noOpStatement
 }
 
 func (m mockOp) QueryExecutor() QueryExecutor {
@@ -105,8 +105,8 @@ func (mo mockMultiOp) RunAtomicallyWithContext(ctx context.Context) error {
 	return mo.WithOptions(Options{Context: ctx}).Run()
 }
 
-func (mo mockMultiOp) GenerateStatement() (string, []interface{}) {
-	return "", []interface{}{}
+func (mo mockMultiOp) GenerateStatement() Statement {
+	return noOpStatement
 }
 
 func (mo mockMultiOp) QueryExecutor() QueryExecutor {
@@ -390,16 +390,16 @@ func (t *MockTable) Create() error {
 	return nil
 }
 
-func (t *MockTable) CreateStatement() (string, error) {
-	return "", nil
+func (t *MockTable) CreateStatement() (Statement, error) {
+	return noOpStatement, nil
 }
 
 func (t *MockTable) CreateIfNotExist() error {
 	return nil
 }
 
-func (t *MockTable) CreateIfNotExistStatement() (string, error) {
-	return "", nil
+func (t *MockTable) CreateIfNotExistStatement() (Statement, error) {
+	return noOpStatement, nil
 }
 
 func (t *MockTable) Recreate() error {

--- a/mock.go
+++ b/mock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"context"
@@ -689,9 +690,20 @@ func (iter *mockIterator) Scan(dest ...interface{}) bool {
 
 		value, ok := result[fieldName]
 		if !ok {
-			// We could panic here but ultimately this will be the zero value of
-			// the resulting pointer and is a valid use case so soldier on
-			continue
+			// See if any fields in result are equal (case insensitive)
+			for k, v := range result {
+				if strings.EqualFold(k, fieldName) {
+					value = v
+					ok = true
+					break
+				}
+			}
+
+			if !ok {
+				// We could panic here but ultimately this will be the zero value of
+				// the resulting pointer and is a valid use case so soldier on
+				continue
+			}
 		}
 
 		// If it's a field to ignore, then ignore it ;)

--- a/mock.go
+++ b/mock.go
@@ -154,14 +154,23 @@ func (mo mockMultiOp) Preflight() error {
 	return nil
 }
 
-func (ks *mockKeySpace) NewTable(name string, entity interface{}, fields map[string]interface{}, keys Keys) Table {
-	return &MockTable{
-		name:   name,
-		entity: entity,
-		keys:   keys,
-		rows:   map[rowKey]*btree.BTree{},
-		mtx:    &sync.RWMutex{},
+func (ks *mockKeySpace) NewTable(name string, entity interface{}, fieldSource map[string]interface{}, keys Keys) Table {
+	mt := &MockTable{
+		name:        name,
+		entity:      entity,
+		keys:        keys,
+		fieldSource: fieldSource,
+		rows:        map[rowKey]*btree.BTree{},
+		mtx:         &sync.RWMutex{},
 	}
+
+	fields := []string{}
+	for _, k := range sortedKeys(fieldSource) {
+		fields = append(fields, k)
+	}
+	mt.fields = fields
+
+	return mt
 }
 
 func NewMockKeySpace() KeySpace {
@@ -175,12 +184,14 @@ type MockTable struct {
 	sync.RWMutex
 
 	// rows is mapping from row key to column group key to column map
-	mtx     *sync.RWMutex
-	name    string
-	rows    map[rowKey]*btree.BTree
-	entity  interface{}
-	keys    Keys
-	options Options
+	mtx         *sync.RWMutex
+	name        string
+	rows        map[rowKey]*btree.BTree
+	entity      interface{}
+	fieldSource map[string]interface{}
+	fields      []string
+	keys        Keys
+	options     Options
 }
 
 type rowKey string
@@ -408,12 +419,14 @@ func (t *MockTable) Recreate() error {
 
 func (t *MockTable) WithOptions(o Options) Table {
 	return &MockTable{
-		name:    t.name,
-		rows:    t.rows,
-		entity:  t.entity,
-		keys:    t.keys,
-		options: t.options.Merge(o),
-		mtx:     t.mtx,
+		name:        t.name,
+		rows:        t.rows,
+		entity:      t.entity,
+		keys:        t.keys,
+		fieldSource: t.fieldSource,
+		fields:      t.fields,
+		options:     t.options.Merge(o),
+		mtx:         t.mtx,
 	}
 }
 
@@ -580,7 +593,15 @@ func (q *MockFilter) Read(out interface{}) Op {
 			result = result[:opt.Limit]
 		}
 
-		return q.assignResult(result, out)
+		fieldNames := opt.Select
+		if len(opt.Select) == 0 {
+			fieldNames = q.table.fields
+		}
+
+		stmt := newSelectStatement("", []interface{}{}, fieldNames)
+		iter := newMockIterator(result, stmt.FieldNames())
+		_, err = newScanner(stmt, out).ScanAll(iter)
+		return err
 	})
 }
 
@@ -630,26 +651,68 @@ func (q *MockFilter) readAllRows() []map[string]interface{} {
 	return result
 }
 
-func (q *MockFilter) assignResult(records interface{}, out interface{}) error {
-	return decodeResult(records, out)
-}
-
 func (q *MockFilter) ReadOne(out interface{}) Op {
 	return newOp(func(m mockOp) error {
-		slicePtrVal := reflect.New(reflect.SliceOf(reflect.ValueOf(out).Elem().Type()))
-
-		err := q.Read(slicePtrVal.Interface()).Run()
-		if err != nil {
-			return err
-		}
-
-		sliceVal := slicePtrVal.Elem()
-		if sliceVal.Len() < 1 {
-			return RowNotFoundError{}
-		}
-		q.assignResult(sliceVal.Index(0).Interface(), out)
-		return nil
+		return q.Read(out).Run()
 	})
+}
+
+type mockIterator struct {
+	results  []map[string]interface{}
+	fields   []string
+	rowsRead int
+}
+
+func newMockIterator(results []map[string]interface{}, fields []string) *mockIterator {
+	return &mockIterator{
+		results:  results,
+		fields:   fields,
+		rowsRead: 0,
+	}
+}
+
+func (iter *mockIterator) Scan(dest ...interface{}) bool {
+	if len(iter.results) == 0 || iter.rowsRead >= len(iter.results) {
+		return false
+	}
+
+	if len(dest) != len(iter.fields) {
+		panic(fmt.Sprintf("expected %d pointers for unmarshalling %d fields", len(dest), len(iter.fields)))
+	}
+
+	result := iter.results[iter.rowsRead]
+	for i, fieldName := range iter.fields {
+		if reflect.TypeOf(dest[i]).Kind() != reflect.Ptr {
+			panic(fmt.Sprintf("expected pointer but got %T", dest[i]))
+		}
+
+		value, ok := result[fieldName]
+		if !ok {
+			// We could panic here but ultiamtely this will be the zero value of
+			// the resulting pointer and is a valid use case so soldier on
+			continue
+		}
+
+		rv := reflect.ValueOf(dest[i])
+
+		// If it's a field to ignore, then ignore it ;)
+		if rv.Elem().Type() == reflect.TypeOf(ignoreFieldType{}) {
+			continue
+		}
+
+		sv := reflect.ValueOf(value)
+		if sv.Type() != rv.Elem().Type() {
+			if !sv.Type().ConvertibleTo(rv.Elem().Type()) {
+				panic(fmt.Sprintf("could not unmarshal %T into %v", value, rv.Elem().Type()))
+			}
+			sv = sv.Convert(rv.Elem().Type())
+		}
+
+		rv.Elem().Set(sv)
+	}
+
+	iter.rowsRead++
+	return true
 }
 
 func assignRecords(m map[string]interface{}, record map[string]interface{}) error {

--- a/mock.go
+++ b/mock.go
@@ -658,6 +658,8 @@ func (q *MockFilter) ReadOne(out interface{}) Op {
 	})
 }
 
+// mockIterator takes in a slice of maps and implements a Scannable iterator
+// which goes row by row within the slice.
 type mockIterator struct {
 	results  []map[string]interface{}
 	fields   []string

--- a/mock.go
+++ b/mock.go
@@ -701,6 +701,9 @@ func (iter *mockIterator) Scan(dest ...interface{}) bool {
 		}
 
 		sv := reflect.ValueOf(value)
+		if !sv.IsValid() { //  Ensure we're not working with the zero value
+			continue
+		}
 
 		// Maps are stored in the mock as map[<KeyType>]interface{}. The receiving value
 		// may be of a different map type so we need to accommodate for this.

--- a/mock.go
+++ b/mock.go
@@ -600,7 +600,7 @@ func (q *MockFilter) Read(out interface{}) Op {
 
 		stmt := newSelectStatement("", []interface{}{}, fieldNames)
 		iter := newMockIterator(result, stmt.FieldNames())
-		_, err = newScanner(stmt, out).ScanAll(iter)
+		_, err = newScanner(stmt, out).ScanIter(iter)
 		return err
 	})
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -21,7 +21,7 @@ type user struct {
 type UserWithMap struct {
 	Id       string
 	Map      map[string]interface{}
-	OtherMap map[int]interface{}
+	OtherMap map[int]string
 }
 
 type point struct {
@@ -76,7 +76,7 @@ func (s *MockSuite) SetupTest() {
 	s.mmapTbl = s.ks.MultimapTable("users", "Pk1", "Pk2", user{})
 	s.tsTbl = s.ks.TimeSeriesTable("points", "Time", "Id", 1*time.Minute, point{})
 	s.mtsTbl = s.ks.MultiTimeSeriesTable("points", "User", "Time", "Id", 1*time.Minute, point{})
-	s.mkTsTbl = s.ks.MultiKeyTimeSeriesTable("points", []string{"X", "Y"}, "Time", []string{"Id"}, 1*time.Minute, user{})
+	s.mkTsTbl = s.ks.MultiKeyTimeSeriesTable("points", []string{"X", "Y"}, "Time", []string{"Id"}, 1*time.Minute, point{})
 
 	s.embMapTbl = s.ks.MapTable("addresses", "Id", address{})
 	s.embTsTbl = s.ks.TimeSeriesTable("addresses", "Time", "Id", 1*time.Minute, address{})
@@ -306,7 +306,7 @@ func (s *MockSuite) TestMapModifiers() {
 			"4": "Four",
 			"6": "Is Even",
 		},
-		OtherMap: map[int]interface{}{
+		OtherMap: map[int]string{
 			1: "One",
 			2: "Two",
 		},

--- a/mock_test.go
+++ b/mock_test.go
@@ -761,3 +761,14 @@ func (s *MockIteratorSuite) TestConvertableTypes() {
 	s.Panics(func() { iter.Scan(&a3, &b3) })
 	iter.Reset()
 }
+
+func (s *MockIteratorSuite) TestValidValues() {
+	t, _ := time.Parse("2006-01-02 15:04:05-0700", "2018-11-13 14:05:36+0000")
+	result := map[string]interface{}{"a": t, "b": nil}
+	iter := newMockIterator([]map[string]interface{}{result}, []string{"a", "b"})
+
+	var a1, b1 time.Time
+	s.True(iter.Scan(&a1, &b1))
+	s.Equal(t, a1)
+	s.Equal(time.Time{}, b1)
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -644,3 +644,103 @@ func (s *MockSuite) parseTime(value string) time.Time {
 	s.NoError(err)
 	return t
 }
+
+func TestRunMockIteratorSuite(t *testing.T) {
+	suite.Run(t, new(MockIteratorSuite))
+}
+
+type MockIteratorSuite struct {
+	suite.Suite
+	*require.Assertions
+}
+
+func (s *MockIteratorSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *MockIteratorSuite) TestBaseBehaviour() {
+	// Test with no results
+	iter := newMockIterator([]map[string]interface{}{}, []string{})
+	s.False(iter.Scan(), "expected scan to fail as there were no results")
+
+	// Test with results but no fields
+	result := map[string]interface{}{"a": "1"}
+	iter = newMockIterator([]map[string]interface{}{result}, []string{})
+	s.True(iter.Scan(), "expected scan to fail as there was one result")
+	s.False(iter.Scan(), "expected scan to fail as there were no more results")
+	s.Equal(1, iter.rowsRead)
+
+	// Test with mismatched fields vs destination ptrs
+	iter = newMockIterator([]map[string]interface{}{result}, []string{"a"})
+	s.Panics(func() { iter.Scan() })
+
+	// Test for passing a struct as a value
+	var res string
+	s.Panics(func() { iter.Scan(res) })
+
+	// Sanity check the happy case, we unmarshal
+	s.True(iter.Scan(&res))
+	s.Equal(1, iter.rowsRead)
+	s.Equal("1", res)
+}
+
+func (s *MockIteratorSuite) TestIgnorableFields() {
+	result := map[string]interface{}{"a": "1", "b": "2", "c": "3"}
+	iter := newMockIterator([]map[string]interface{}{result}, []string{"a", "b"})
+
+	// Test reading all the things
+	var a1, b1 string
+	s.True(iter.Scan(&a1, &b1))
+	s.Equal("1", a1)
+	s.Equal("2", b1)
+	iter.Reset()
+
+	// Test ignorable things
+	var a2, b2 string
+	s.True(iter.Scan(&a2, &ignoreFieldType{}))
+	s.Equal("1", a2)
+	s.Equal("", b2)
+	iter.Reset()
+	s.True(iter.Scan(&ignoreFieldType{}, &b2))
+	s.Equal("2", b2)
+	iter.Reset()
+
+	// Test ignoring everything
+	s.True(iter.Scan(&ignoreFieldType{}, &ignoreFieldType{}))
+	iter.Reset()
+
+	result = map[string]interface{}{"a": "1", "b": "2", "c": "3"}
+	iter = newMockIterator([]map[string]interface{}{result}, []string{"e", "f"})
+
+	// Test fields not present in results
+	var e3, f3 string
+	s.True(iter.Scan(&e3, &f3))
+	s.Equal("", e3)
+	s.Equal("", f3)
+	iter.Reset()
+}
+
+func (s *MockIteratorSuite) TestConvertableTypes() {
+	type Status string
+
+	result := map[string]interface{}{"a": "1", "b": "2", "c": "3"}
+	iter := newMockIterator([]map[string]interface{}{result}, []string{"a", "b"})
+
+	// Test we can convert between sensible types
+	var a1, b1 Status
+	s.True(iter.Scan(&a1, &b1))
+	s.Equal(Status("1"), a1)
+	s.Equal(Status("2"), b1)
+	iter.Reset()
+
+	var a2, b2 []byte
+	s.True(iter.Scan(&a2, &b2))
+	s.Equal("1", string(a2))
+	s.Equal("2", string(b2))
+	iter.Reset()
+
+	// Test we can't convert into a nonsense type
+	var a3, b3 int
+	s.Panics(func() { iter.Scan(&a3, &b3) })
+	iter.Reset()
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -21,7 +21,7 @@ type user struct {
 type UserWithMap struct {
 	Id       string
 	Map      map[string]interface{}
-	OtherMap map[int]string
+	OtherMap map[int]interface{}
 }
 
 type point struct {
@@ -306,7 +306,7 @@ func (s *MockSuite) TestMapModifiers() {
 			"4": "Four",
 			"6": "Is Even",
 		},
-		OtherMap: map[int]string{
+		OtherMap: map[int]interface{}{
 			1: "One",
 			2: "Two",
 		},
@@ -718,6 +718,23 @@ func (s *MockIteratorSuite) TestIgnorableFields() {
 	s.Equal("", e3)
 	s.Equal("", f3)
 	iter.Reset()
+}
+
+func (s *MockIteratorSuite) TestMapConversionTypes() {
+	result := map[string]interface{}{
+		"a": map[string]interface{}{"a1": "1", "a2": "2"},
+		"b": map[string]interface{}{"b1": 1, "b2": 2},
+		"c": map[string]interface{}{"c1": float32(1.0), "c2": float32(2.0)},
+	}
+
+	iter := newMockIterator([]map[string]interface{}{result}, []string{"a", "b", "c"})
+	var a map[string]string
+	var b map[string]int
+	var c map[string]float32
+	s.True(iter.Scan(&a, &b, &c))
+	s.Equal("1", a["a1"])
+	s.Equal(2, b["b2"])
+	s.Equal(float32(1.0), c["c1"])
 }
 
 func (s *MockIteratorSuite) TestConvertableTypes() {

--- a/multiflakeseries_table.go
+++ b/multiflakeseries_table.go
@@ -12,13 +12,13 @@ type multiFlakeSeriesT struct {
 	bucketSize time.Duration
 }
 
-func (o *multiFlakeSeriesT) Table() Table                     { return o.t }
-func (o *multiFlakeSeriesT) Create() error                    { return o.Table().Create() }
-func (o *multiFlakeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
-func (o *multiFlakeSeriesT) Name() string                     { return o.Table().Name() }
-func (o *multiFlakeSeriesT) Recreate() error                  { return o.Table().Recreate() }
-func (o *multiFlakeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
-func (o *multiFlakeSeriesT) CreateIfNotExistStatement() (string, error) {
+func (o *multiFlakeSeriesT) Table() Table                        { return o.t }
+func (o *multiFlakeSeriesT) Create() error                       { return o.Table().Create() }
+func (o *multiFlakeSeriesT) CreateIfNotExist() error             { return o.Table().CreateIfNotExist() }
+func (o *multiFlakeSeriesT) Name() string                        { return o.Table().Name() }
+func (o *multiFlakeSeriesT) Recreate() error                     { return o.Table().Recreate() }
+func (o *multiFlakeSeriesT) CreateStatement() (Statement, error) { return o.Table().CreateStatement() }
+func (o *multiFlakeSeriesT) CreateIfNotExistStatement() (Statement, error) {
 	return o.Table().CreateIfNotExistStatement()
 }
 

--- a/multikey_timeseries_table.go
+++ b/multikey_timeseries_table.go
@@ -12,13 +12,13 @@ type multiKeyTimeSeriesT struct {
 	bucketSize  time.Duration
 }
 
-func (o *multiKeyTimeSeriesT) Table() Table                     { return o.t }
-func (o *multiKeyTimeSeriesT) Create() error                    { return o.Table().Create() }
-func (o *multiKeyTimeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
-func (o *multiKeyTimeSeriesT) Name() string                     { return o.Table().Name() }
-func (o *multiKeyTimeSeriesT) Recreate() error                  { return o.Table().Recreate() }
-func (o *multiKeyTimeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
-func (o *multiKeyTimeSeriesT) CreateIfNotExistStatement() (string, error) {
+func (o *multiKeyTimeSeriesT) Table() Table                        { return o.t }
+func (o *multiKeyTimeSeriesT) Create() error                       { return o.Table().Create() }
+func (o *multiKeyTimeSeriesT) CreateIfNotExist() error             { return o.Table().CreateIfNotExist() }
+func (o *multiKeyTimeSeriesT) Name() string                        { return o.Table().Name() }
+func (o *multiKeyTimeSeriesT) Recreate() error                     { return o.Table().Recreate() }
+func (o *multiKeyTimeSeriesT) CreateStatement() (Statement, error) { return o.Table().CreateStatement() }
+func (o *multiKeyTimeSeriesT) CreateIfNotExistStatement() (Statement, error) {
 	return o.Table().CreateIfNotExistStatement()
 }
 

--- a/multimap_multikey_table.go
+++ b/multimap_multikey_table.go
@@ -6,13 +6,13 @@ type multimapMkT struct {
 	idField         []string
 }
 
-func (mm *multimapMkT) Table() Table                     { return mm.t }
-func (mm *multimapMkT) Create() error                    { return mm.Table().Create() }
-func (mm *multimapMkT) CreateIfNotExist() error          { return mm.Table().CreateIfNotExist() }
-func (mm *multimapMkT) Name() string                     { return mm.Table().Name() }
-func (mm *multimapMkT) Recreate() error                  { return mm.Table().Recreate() }
-func (mm *multimapMkT) CreateStatement() (string, error) { return mm.Table().CreateStatement() }
-func (mm *multimapMkT) CreateIfNotExistStatement() (string, error) {
+func (mm *multimapMkT) Table() Table                        { return mm.t }
+func (mm *multimapMkT) Create() error                       { return mm.Table().Create() }
+func (mm *multimapMkT) CreateIfNotExist() error             { return mm.Table().CreateIfNotExist() }
+func (mm *multimapMkT) Name() string                        { return mm.Table().Name() }
+func (mm *multimapMkT) Recreate() error                     { return mm.Table().Recreate() }
+func (mm *multimapMkT) CreateStatement() (Statement, error) { return mm.Table().CreateStatement() }
+func (mm *multimapMkT) CreateIfNotExistStatement() (Statement, error) {
 	return mm.Table().CreateIfNotExistStatement()
 }
 

--- a/multimap_table.go
+++ b/multimap_table.go
@@ -6,13 +6,13 @@ type multimapT struct {
 	idField        string
 }
 
-func (mm *multimapT) Table() Table                     { return mm.t }
-func (mm *multimapT) Create() error                    { return mm.Table().Create() }
-func (mm *multimapT) CreateIfNotExist() error          { return mm.Table().CreateIfNotExist() }
-func (mm *multimapT) Name() string                     { return mm.Table().Name() }
-func (mm *multimapT) Recreate() error                  { return mm.Table().Recreate() }
-func (mm *multimapT) CreateStatement() (string, error) { return mm.Table().CreateStatement() }
-func (mm *multimapT) CreateIfNotExistStatement() (string, error) {
+func (mm *multimapT) Table() Table                        { return mm.t }
+func (mm *multimapT) Create() error                       { return mm.Table().Create() }
+func (mm *multimapT) CreateIfNotExist() error             { return mm.Table().CreateIfNotExist() }
+func (mm *multimapT) Name() string                        { return mm.Table().Name() }
+func (mm *multimapT) Recreate() error                     { return mm.Table().Recreate() }
+func (mm *multimapT) CreateStatement() (Statement, error) { return mm.Table().CreateStatement() }
+func (mm *multimapT) CreateIfNotExistStatement() (Statement, error) {
 	return mm.Table().CreateIfNotExistStatement()
 }
 

--- a/multiop.go
+++ b/multiop.go
@@ -32,25 +32,23 @@ func (mo multiOp) RunAtomically() error {
 	if err := mo.Preflight(); err != nil {
 		return err
 	}
-	stmts := make([]string, len(mo))
-	vals := make([][]interface{}, len(mo))
+	stmts := make([]Statement, len(mo))
 	var qe QueryExecutor
 	for i, op := range mo {
-		s, v := op.GenerateStatement()
+		s := op.GenerateStatement()
 		qe = op.QueryExecutor()
 		stmts[i] = s
-		vals[i] = v
 	}
 
-	return qe.ExecuteAtomicallyWithOptions(mo.Options(), stmts, vals)
+	return qe.ExecuteAtomicallyWithOptions(mo.Options(), stmts)
 }
 
 func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
 	return mo.WithOptions(Options{Context: ctx}).RunAtomically()
 }
 
-func (mo multiOp) GenerateStatement() (string, []interface{}) {
-	return "", []interface{}{}
+func (mo multiOp) GenerateStatement() Statement {
+	return noOpStatement
 }
 
 func (mo multiOp) QueryExecutor() QueryExecutor {

--- a/multiop.go
+++ b/multiop.go
@@ -33,13 +33,12 @@ func (mo multiOp) RunAtomically() error {
 		return err
 	}
 	stmts := make([]Statement, len(mo))
-	var qe QueryExecutor
 	for i, op := range mo {
 		s := op.GenerateStatement()
-		qe = op.QueryExecutor()
 		stmts[i] = s
 	}
 
+	qe := mo.QueryExecutor()
 	return qe.ExecuteAtomicallyWithOptions(mo.Options(), stmts)
 }
 

--- a/multitimeseries_table.go
+++ b/multitimeseries_table.go
@@ -12,13 +12,13 @@ type multiTimeSeriesT struct {
 	bucketSize time.Duration
 }
 
-func (o *multiTimeSeriesT) Table() Table                     { return o.t }
-func (o *multiTimeSeriesT) Create() error                    { return o.Table().Create() }
-func (o *multiTimeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
-func (o *multiTimeSeriesT) Name() string                     { return o.Table().Name() }
-func (o *multiTimeSeriesT) Recreate() error                  { return o.Table().Recreate() }
-func (o *multiTimeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
-func (o *multiTimeSeriesT) CreateIfNotExistStatement() (string, error) {
+func (o *multiTimeSeriesT) Table() Table                        { return o.t }
+func (o *multiTimeSeriesT) Create() error                       { return o.Table().Create() }
+func (o *multiTimeSeriesT) CreateIfNotExist() error             { return o.Table().CreateIfNotExist() }
+func (o *multiTimeSeriesT) Name() string                        { return o.Table().Name() }
+func (o *multiTimeSeriesT) Recreate() error                     { return o.Table().Recreate() }
+func (o *multiTimeSeriesT) CreateStatement() (Statement, error) { return o.Table().CreateStatement() }
+func (o *multiTimeSeriesT) CreateIfNotExistStatement() (Statement, error) {
 	return o.Table().CreateIfNotExistStatement()
 }
 

--- a/op.go
+++ b/op.go
@@ -157,7 +157,8 @@ func (o *singleOp) generateWrite(opt Options) Statement {
 func (o *singleOp) generateRead(opt Options) Statement {
 	w, wv := generateWhere(o.f.rs)
 	mopt := o.f.t.options.Merge(opt)
-	fl := o.f.t.generateColumnFieldList(mopt.Select)
+	fl := o.f.t.generateFieldList(mopt.Select)
+	ft := o.f.t.generateFieldTypes(fl)
 	ord, ov := o.generateOrderBy(mopt)
 	lim, lv := o.generateLimit(mopt)
 	stmt := fmt.Sprintf("SELECT %s FROM %s.%s", strings.Join(fl, ","), o.f.t.keySpace.name, o.f.t.Name())
@@ -186,7 +187,7 @@ func (o *singleOp) generateRead(opt Options) Statement {
 	if o.f.t.keySpace.debugMode {
 		fmt.Println(buf.String(), vals)
 	}
-	return newSelectStatement(buf.String(), vals, fl)
+	return newSelectStatement(buf.String(), vals, fl, ft)
 }
 
 func (o *singleOp) generateOrderBy(opt Options) (string, []interface{}) {

--- a/op.go
+++ b/op.go
@@ -60,22 +60,13 @@ func newWriteOp(qe QueryExecutor, f filter, opType uint8, m map[string]interface
 func (w *singleOp) read() error {
 	stmt := w.generateRead(w.options).(statement)
 	scanner := newScanner(stmt, w.result)
-	err := w.qe.QueryWithOptions(w.options, stmt, scanner)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return w.qe.QueryWithOptions(w.options, stmt, scanner)
 }
 
 func (w *singleOp) readOne() error {
 	stmt := w.generateRead(w.options).(statement)
 	scanner := newScanner(stmt, w.result)
-	err := w.qe.QueryWithOptions(w.options, stmt, scanner)
-	if err != nil {
-		return err
-	}
-	return nil
+	return w.qe.QueryWithOptions(w.options, stmt, scanner)
 }
 
 func (w *singleOp) write() error {

--- a/op_test.go
+++ b/op_test.go
@@ -1,10 +1,8 @@
 package gocassa
 
 import (
-	"reflect"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/gocql/gocql"
 )
@@ -70,36 +68,6 @@ var opTestRowExpected = OpTestStruct{
 	},
 }
 
-func TestDecodeRow(t *testing.T) {
-	var result []OpTestStruct
-
-	err := decodeResult([]map[string]interface{}{opTestRow}, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(result) != 1 {
-		t.Fatalf("Expected 1 results, got %d", len(result))
-	}
-
-	if !reflect.DeepEqual(result, []OpTestStruct{opTestRowExpected}) {
-		t.Fatalf("Did not get expected result")
-	}
-}
-
-func TestDecodeSingleRow(t *testing.T) {
-	var result OpTestStruct
-
-	err := decodeResult(opTestRow, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(result, opTestRowExpected) {
-		t.Fatalf("Did not get expected result")
-	}
-}
-
 type OpTestCompositeType struct {
 	Num int
 	Str string
@@ -132,34 +100,4 @@ func (t *OpTestEnumType) UnmarshalCQL(_ gocql.TypeInfo, data []byte) error {
 	}
 	*t = values[string(data)]
 	return nil
-}
-
-type OpTestUnmarshalCQLStruct struct {
-	A string
-	B *OpTestCompositeType
-	C OpTestEnumType
-}
-
-var opTestUnmarshalCQLRow = map[string]interface{}{
-	"A": "a",
-	"B": "42 CQL",
-	"C": "EnumTwo",
-}
-
-var opTestUnmarshalCQLRowExpected = OpTestUnmarshalCQLStruct{
-	A: "a",
-	B: &OpTestCompositeType{Num: 42, Str: "CQL"},
-	C: OpTestEnumType(2),
-}
-
-func TestDecodeUnmarshalCQL(t *testing.T) {
-	var result OpTestUnmarshalCQLStruct
-	err := decodeResult(opTestUnmarshalCQLRow, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(result, opTestUnmarshalCQLRowExpected) {
-		t.Fatalf("Did not get expected result")
-	}
 }

--- a/reflect/cache.go
+++ b/reflect/cache.go
@@ -123,6 +123,10 @@ func typeFields(t reflect.Type) []Field {
 				index[len(f.index)] = i
 
 				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr && sf.Anonymous {
+					// Follow pointer for embedded types
+					ft = ft.Elem()
+				}
 
 				// Record found field and index sequence.
 				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {

--- a/reflect/cache.go
+++ b/reflect/cache.go
@@ -123,10 +123,6 @@ func typeFields(t reflect.Type) []Field {
 				index[len(f.index)] = i
 
 				ft := sf.Type
-				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
-					// Follow pointer.
-					ft = ft.Elem()
-				}
 
 				// Record found field and index sequence.
 				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -35,7 +35,20 @@ func StructToMap(val interface{}) (map[string]interface{}, bool) {
 	return mapVal, true
 }
 
-// StructFieldMap takes a struct and extracts the field types into a map
+// StructFieldMap takes a struct and extracts the Field info into a map by
+// field name. The "cql" key in the struct field's tag value is the key
+// name. Examples:
+//
+//   // Field appears in the resulting map as key "myName".
+//   Field int `cql:"myName"`
+//
+//   // Field appears in the resulting as key "Field"
+//   Field int
+//
+//   // Field appears in the resulting map as key "myName"
+//   Field int "myName"
+//
+// If lowercaseFields is set to true, field names are lowercased in the map
 func StructFieldMap(val interface{}, lowercaseFields bool) (map[string]Field, bool) {
 	// indirect so function works with both structs and pointers to them
 	structVal := r.Indirect(r.ValueOf(val))

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -2,6 +2,7 @@
 package reflect
 
 import (
+	"fmt"
 	r "reflect"
 	"strings"
 )
@@ -49,13 +50,14 @@ func StructToMap(val interface{}) (map[string]interface{}, bool) {
 //   Field int "myName"
 //
 // If lowercaseFields is set to true, field names are lowercased in the map
-func StructFieldMap(val interface{}, lowercaseFields bool) (map[string]Field, bool) {
+func StructFieldMap(val interface{}, lowercaseFields bool) (map[string]Field, error) {
 	// indirect so function works with both structs and pointers to them
 	structVal := r.Indirect(r.ValueOf(val))
 	kind := structVal.Kind()
 	if kind != r.Struct {
-		return nil, false
+		return nil, fmt.Errorf("expected val to be a struct, got %T", val)
 	}
+
 	structFields := cachedTypeFields(structVal.Type())
 	mapVal := make(map[string]Field, len(structFields))
 	for _, info := range structFields {
@@ -65,7 +67,7 @@ func StructFieldMap(val interface{}, lowercaseFields bool) (map[string]Field, bo
 		}
 		mapVal[name] = info
 	}
-	return mapVal, true
+	return mapVal, nil
 }
 
 // MapToStruct converts a map to a struct. It is the inverse of the StructToMap

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -138,9 +138,9 @@ func TestMapToStruct(t *testing.T) {
 }
 
 func TestStructFieldMap(t *testing.T) {
-	m, ok := StructFieldMap(Tweet{}, false)
-	if !ok {
-		t.Fatalf("expected field map to be created")
+	m, err := StructFieldMap(Tweet{}, false)
+	if err != nil {
+		t.Fatalf("expected field map to be created, err: %v", err)
 	}
 
 	if timeline, ok := m["Timeline"]; ok {
@@ -185,7 +185,11 @@ func TestStructFieldMap(t *testing.T) {
 	}
 
 	// Test lowercasing fields
-	m2, ok := StructFieldMap(Tweet{}, true)
+	m2, err := StructFieldMap(Tweet{}, true)
+	if err != nil {
+		t.Fatalf("expected field map to be created, err: %v", err)
+	}
+
 	if timeline, ok := m2["timeline"]; !ok {
 		if timeline.Name() != "Timeline" {
 			t.Errorf("Timeline should have name 'Timeline' but got %s", timeline.Name())
@@ -199,9 +203,9 @@ func TestStructFieldMapEmbeddedStruct(t *testing.T) {
 		Embedder string
 	}
 
-	m, ok := StructFieldMap(EmbeddedTweet{}, false)
-	if !ok {
-		t.Fatalf("expected field map to be created")
+	m, err := StructFieldMap(EmbeddedTweet{}, false)
+	if err != nil {
+		t.Fatalf("expected field map to be created, err: %v", err)
 	}
 
 	if timeline, ok := m["Timeline"]; ok {
@@ -227,7 +231,13 @@ func TestStructFieldMapEmbeddedStruct(t *testing.T) {
 	} else {
 		t.Errorf("Embedder should be present but wasn't: %+v", m)
 	}
+}
 
+func TestStructFieldMapNonStruct(t *testing.T) {
+	_, err := StructFieldMap(42, false)
+	if err == nil {
+		t.Fatalf("expected StructFieldMap to have an error, got nil error")
+	}
 }
 
 func TestFieldsAndValues(t *testing.T) {

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -193,6 +193,43 @@ func TestStructFieldMap(t *testing.T) {
 	}
 }
 
+func TestStructFieldMapEmbeddedStruct(t *testing.T) {
+	type EmbeddedTweet struct {
+		*Tweet   `cql:",squash"`
+		Embedder string
+	}
+
+	m, ok := StructFieldMap(EmbeddedTweet{}, false)
+	if !ok {
+		t.Fatalf("expected field map to be created")
+	}
+
+	if timeline, ok := m["Timeline"]; ok {
+		if timeline.Name() != "Timeline" {
+			t.Errorf("Timeline should have name 'Timeline' but got %s", timeline.Name())
+		}
+
+		if timeline.Type() != reflect.TypeOf("") {
+			t.Errorf("Timeline have type 'string' but got %s", timeline.Type())
+		}
+	} else {
+		t.Errorf("Timeline should be present but wasn't: %+v", m)
+	}
+
+	if embedder, ok := m["Embedder"]; ok {
+		if embedder.Name() != "Embedder" {
+			t.Errorf("Embedder should have name 'Embedder' but got %s", embedder.Name())
+		}
+
+		if embedder.Type() != reflect.TypeOf("") {
+			t.Errorf("Embedder have type 'string' but got %s", embedder.Type())
+		}
+	} else {
+		t.Errorf("Embedder should be present but wasn't: %+v", m)
+	}
+
+}
+
 func TestFieldsAndValues(t *testing.T) {
 	var emptyUUID gocql.UUID
 	id := gocql.TimeUUID()

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -54,7 +54,7 @@ func TestStructToMap(t *testing.T) {
 		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
 	}
 	if _, ok := m["Ignored"]; ok {
-		t.Errorf("Igonred should be empty but got %s instead", m["Ignored"])
+		t.Errorf("Ignored should be empty but got %s instead", m["Ignored"])
 	}
 
 	id := gocql.TimeUUID()

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -1,6 +1,8 @@
 package reflect
 
 import (
+	"reflect"
+
 	"github.com/gocql/gocql"
 
 	"testing"
@@ -9,7 +11,7 @@ import (
 type Tweet struct {
 	Timeline      string
 	ID            gocql.UUID `cql:"id"`
-	Ingored       string     `cql:"-"`
+	Ignored       string     `cql:"-"`
 	Text          string
 	OriginalTweet *gocql.UUID `json:"origin"`
 }
@@ -51,7 +53,7 @@ func TestStructToMap(t *testing.T) {
 	if m["OriginalTweet"] != tweet.OriginalTweet {
 		t.Errorf("Expected %v but got %s", tweet.OriginalTweet, m["OriginalTweet"])
 	}
-	if _, ok := m["Ignore"]; ok {
+	if _, ok := m["Ignored"]; ok {
 		t.Errorf("Igonred should be empty but got %s instead", m["Ignored"])
 	}
 
@@ -64,7 +66,6 @@ func TestStructToMap(t *testing.T) {
 }
 
 func TestMapToStruct(t *testing.T) {
-
 	m := make(map[string]interface{})
 	assert := func() {
 		tweet := Tweet{}
@@ -116,9 +117,9 @@ func TestMapToStruct(t *testing.T) {
 			}
 		}
 		//Ignored should be always empty
-		if tweet.Ingored != "" {
+		if tweet.Ignored != "" {
 			t.Errorf("Expected ignored to be empty but got %s",
-				tweet.Ingored)
+				tweet.Ignored)
 		}
 	}
 
@@ -134,6 +135,62 @@ func TestMapToStruct(t *testing.T) {
 	assert()
 	m["Ignored"] = "ignored"
 	assert()
+}
+
+func TestStructFieldMap(t *testing.T) {
+	m, ok := StructFieldMap(Tweet{}, false)
+	if !ok {
+		t.Fatalf("expected field map to be created")
+	}
+
+	if timeline, ok := m["Timeline"]; ok {
+		if timeline.Name() != "Timeline" {
+			t.Errorf("Timeline should have name 'Timeline' but got %s", timeline.Name())
+		}
+
+		if timeline.Type() != reflect.TypeOf("") {
+			t.Errorf("Timeline have type 'string' but got %s", timeline.Type())
+		}
+	} else {
+		t.Errorf("Timeline should be present but wasn't: %+v", m)
+	}
+
+	if id, ok := m["id"]; ok {
+		if id.Name() != "id" {
+			t.Errorf("ID should have name 'id' but got %s", id.Name())
+		}
+
+		if id.Type() != reflect.TypeOf(gocql.UUID([16]byte{})) {
+			t.Errorf("ID have type 'gocql.UUID' but got %s", id.Type())
+		}
+	} else {
+		t.Errorf("ID should be present but wasn't: %+v", m)
+	}
+
+	if ot, ok := m["OriginalTweet"]; ok {
+		if ot.Name() != "OriginalTweet" {
+			t.Errorf("OriginalTweet should have name 'OriginalTweet' but got %s", ot.Name())
+		}
+
+		u := gocql.UUID([16]byte{})
+		if ot.Type() != reflect.TypeOf(&u) {
+			t.Errorf("OriginalTweet have type '*gocql.UUID' but got %s", ot.Type())
+		}
+	} else {
+		t.Errorf("OriginalTweet should be present but wasn't: %+v", m)
+	}
+
+	if _, ok := m["Ignored"]; ok {
+		t.Errorf("Ignored should not be present but got %v instead", m["Ignored"])
+	}
+
+	// Test lowercasing fields
+	m2, ok := StructFieldMap(Tweet{}, true)
+	if timeline, ok := m2["timeline"]; !ok {
+		if timeline.Name() != "Timeline" {
+			t.Errorf("Timeline should have name 'Timeline' but got %s", timeline.Name())
+		}
+	}
 }
 
 func TestFieldsAndValues(t *testing.T) {

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,219 @@
+package gocassa
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/gocql/gocql"
+
+	r "github.com/monzo/gocassa/reflect"
+)
+
+type scanner struct {
+	stmt statement
+
+	result   interface{}
+	rowCount int
+}
+
+func newScanner(stmt statement, result interface{}) *scanner {
+	return &scanner{
+		stmt:     stmt,
+		result:   result,
+		rowCount: 0,
+	}
+}
+
+func getType(in interface{}) reflect.Type {
+	elem := reflect.TypeOf(in)
+	for elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	return elem
+}
+
+func getSliceValueType(in interface{}) reflect.Type {
+	elem := getType(in).Elem()
+	if elem.Kind() == reflect.Ptr {
+		elem = elem.Elem()
+	}
+	return elem
+}
+
+func (s *scanner) ScanAll(iter Scannable) (int, error) {
+	switch getType(s.result).Kind() { // TODO: optimise this
+	case reflect.Slice:
+		return s.iterSlice(iter)
+	case reflect.Struct:
+		// We are reading a single element here, decode a single row
+		return s.iterSingle(iter)
+	}
+
+	return 0, fmt.Errorf("can only decode into a struct or slice of structs, not %T", s.result)
+}
+
+func (s *scanner) iterSlice(iter Scannable) (int, error) {
+	// Extract the type of the slice
+	// TODO(suhail): Name these better!
+	sliceType := getType(s.result)
+	sliceElemType := sliceType.Elem()
+	sliceElemValType := getSliceValueType(s.result)
+
+	// To preserve prior bebaviour, if the result slice is not empty
+	// then allocate a new slice and set it as the value
+	slice := reflect.ValueOf(s.result).Elem()
+	if slice.Len() != 0 {
+		slice.Set(reflect.Zero(sliceType))
+	}
+
+	fmPtr := reflect.New(sliceElemValType).Interface() // TODO: could we not do this
+	m, ok := r.StructFieldMap(fmPtr, true)
+	if !ok {
+		return 0, fmt.Errorf("could not decode struct of type %T", fmPtr)
+	}
+
+	structFields := s.structFields(m)
+	generatePtrs := func() []interface{} {
+		ptrs := []interface{}{}
+		for _, sf := range structFields {
+			if sf != nil {
+				val := reflect.New(sf.Type())
+				ptrs = append(ptrs, val.Interface())
+			} else {
+				ptrs = append(ptrs, &ignoreFieldType{})
+			}
+		}
+		return ptrs
+	}
+
+	ptrs := generatePtrs()
+
+	for iter.Scan(ptrs...) {
+		outPtr := reflect.New(sliceElemValType)
+		outVal := outPtr.Elem()
+
+		for index, field := range structFields {
+			if field == nil {
+				continue
+			}
+
+			outField := outVal.FieldByIndex(field.Index())
+			if outField.CanSet() {
+				outField.Set(reflect.ValueOf(ptrs[index]).Elem())
+			}
+		}
+
+		if sliceElemType.Kind() == reflect.Ptr {
+			slice.Set(reflect.Append(slice, outPtr))
+		} else {
+			slice.Set(reflect.Append(slice, outVal))
+		}
+
+		ptrs = generatePtrs()
+		s.rowCount++
+	}
+	return s.rowCount, nil
+}
+
+func (s *scanner) iterSingle(iter Scannable) (int, error) {
+	resultBaseType := getType(s.result)
+	fmPtr := reflect.New(resultBaseType).Interface() // TODO: could we not do this
+	m, ok := r.StructFieldMap(fmPtr, true)
+	if !ok {
+		return 0, fmt.Errorf("could not decode struct of type %T", fmPtr)
+	}
+
+	// If we're given a pointer to a ptr which is nil, we are
+	// responsible for allocating it before we assign. Note that
+	// this could be a ptr to a ptr (and so forth)
+	outPtr := reflect.ValueOf(s.result)
+	outVal := outPtr.Elem()
+	if outVal.Kind() == reflect.Ptr && outVal.IsNil() {
+		allocateResult(s.result)
+	}
+	for outVal.Kind() == reflect.Ptr {
+		outVal = outVal.Elem() // we will eventually get to the underlying type
+	}
+
+	structFields := s.structFields(m)
+	generatePtrs := func() []interface{} {
+		ptrs := []interface{}{}
+		for _, sf := range structFields {
+			if sf != nil {
+				val := reflect.New(sf.Type())
+				ptrs = append(ptrs, val.Interface())
+			} else {
+				ptrs = append(ptrs, &ignoreFieldType{})
+			}
+		}
+		return ptrs
+	}
+
+	ptrs := generatePtrs()
+	scanOk := iter.Scan(ptrs...) // we only need to scan once
+	if !scanOk {
+		return 0, RowNotFoundError{}
+	}
+
+	for index, field := range structFields {
+		if field == nil {
+			continue
+		}
+
+		outField := outVal.FieldByIndex(field.Index())
+		if outField.CanSet() {
+			outField.Set(reflect.ValueOf(ptrs[index]).Elem())
+		}
+	}
+
+	s.rowCount++
+	return s.rowCount, nil
+}
+
+func (s *scanner) structFields(m map[string]r.Field) []*r.Field {
+	structFields := []*r.Field{}
+	for _, fieldName := range s.stmt.fieldNames {
+		field, ok := m[strings.ToLower(fieldName)]
+		if !ok { // the field doesn't have a destination
+			structFields = append(structFields, nil)
+		} else {
+			structFields = append(structFields, &field)
+		}
+	}
+	return structFields
+}
+
+func allocateResult(in interface{}) {
+	resultType := reflect.TypeOf(in)
+	resultValType := resultType.Elem()
+
+	// Here we unravel the underlying base type, it's just
+	// pointer turtles all the way down
+	baseType := resultType
+	for baseType.Kind() == reflect.Ptr {
+		baseType = baseType.Elem()
+	}
+
+	// Then we work our way backwards by wrapping pointers with
+	// more pointers until we get the result type
+	structPtr := reflect.New(baseType)
+	resultPtr := structPtr
+	for resultPtr.Type() != resultValType {
+		ptr := reflect.New(resultPtr.Type())
+		ptr.Elem().Set(resultPtr)
+		resultPtr = ptr
+	}
+
+	reflect.ValueOf(in).Elem().Set(resultPtr)
+}
+
+// This struct is for fields we want to ignore, we specify a custom unmarshal
+// type which literally is a no-op and does nothing with this data. In the
+// future, maybe we can be smarter of only extracting fields which we are
+// able to unmarshal into our target struct
+type ignoreFieldType struct{}
+
+func (i *ignoreFieldType) UnmarshalCQL(_ gocql.TypeInfo, _ []byte) error {
+	return nil
+}

--- a/scanner.go
+++ b/scanner.go
@@ -118,13 +118,13 @@ func (s *scanner) structFields(structType reflect.Type) ([]*r.Field, error) {
 		return nil, fmt.Errorf("could not decode struct of type %T", fmPtr)
 	}
 
-	structFields := []*r.Field{}
-	for _, fieldName := range s.stmt.fieldNames {
+	structFields := make([]*r.Field, len(s.stmt.fieldNames))
+	for i, fieldName := range s.stmt.fieldNames {
 		field, ok := m[strings.ToLower(fieldName)]
 		if !ok { // the field doesn't have a destination
-			structFields = append(structFields, nil)
+			structFields[i] = nil
 		} else {
-			structFields = append(structFields, &field)
+			structFields[i] = &field
 		}
 	}
 	return structFields, nil

--- a/scanner.go
+++ b/scanner.go
@@ -122,9 +122,9 @@ func (s *scanner) iterSingle(iter Scannable) (int, error) {
 // within the target struct type
 func (s *scanner) structFields(structType reflect.Type) ([]*r.Field, error) {
 	fmPtr := reflect.New(structType).Interface()
-	m, ok := r.StructFieldMap(fmPtr, true)
-	if !ok {
-		return nil, fmt.Errorf("could not decode struct of type %T", fmPtr)
+	m, err := r.StructFieldMap(fmPtr, true)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode struct of type %T: %v", fmPtr, err)
 	}
 
 	structFields := make([]*r.Field, len(s.stmt.fieldNames))

--- a/scanner.go
+++ b/scanner.go
@@ -156,6 +156,16 @@ func setPtrs(structFields []*r.Field, ptrs []interface{}, targetStruct reflect.V
 			continue
 		}
 
+		// Handle the case where the embedded struct hasn't been allocated yet
+		// if it's a pointer. Because these are anonymous, if they are nil we
+		// can't access them! We could be smarter here in the future...
+		if len(field.Index()) > 1 {
+			elem := targetStruct.FieldByIndex([]int{field.Index()[0]})
+			if elem.Kind() == reflect.Ptr && elem.IsNil() {
+				continue
+			}
+		}
+
 		elem := targetStruct.FieldByIndex(field.Index())
 		if elem.CanSet() {
 			data := reflect.ValueOf(ptrs[index]).Elem()

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,257 @@
+package gocassa
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type account struct {
+	ID   string
+	Name string
+}
+
+func TestScanIterSlice(t *testing.T) {
+	results := []map[string]interface{}{
+		{"id": "acc_abcd1", "name": "John", "created": "2018-05-01 19:00:00+0000"},
+		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
+	}
+
+	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "created"})
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	expected := []account{
+		{ID: "acc_abcd1", Name: "John"},
+		{ID: "acc_abcd2", Name: "Jane"},
+	}
+
+	// Test with decoding into a slice of structs
+	a1 := []account{}
+	rowsRead, err := newScanner(stmt, &a1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected, a1)
+	iter.Reset()
+
+	// Test with decoding into a pointer of slice of structs
+	b1 := &[]account{}
+	rowsRead, err = newScanner(stmt, &b1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected, *b1)
+	iter.Reset()
+
+	// Test with decoding into a pre-populated struct. It should
+	// remove existing elements
+	c1 := &[]account{{ID: "acc_abcd3", Name: "Joe"}}
+	rowsRead, err = newScanner(stmt, &c1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected, *c1)
+	iter.Reset()
+
+	// Test decoding into a nil slice
+	var d1 []account
+	assert.Nil(t, d1)
+	rowsRead, err = newScanner(stmt, &d1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected, d1)
+	iter.Reset()
+
+	// Test decoding into a pointer of pointer of nil-ness
+	var e1 **[]account
+	assert.Nil(t, e1)
+	rowsRead, err = newScanner(stmt, &e1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected, **e1)
+	iter.Reset()
+
+	// Test decoding into a slice of pointers
+	var f1 []*account
+	assert.Nil(t, f1)
+	rowsRead, err = newScanner(stmt, &f1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, expected[0], *f1[0])
+	assert.Equal(t, expected[1], *f1[1])
+	iter.Reset()
+
+	// Test decoding into a completely tangent struct
+	type fakeStruct struct {
+		Foo string
+		Bar string
+	}
+	var g1 []fakeStruct
+	assert.Nil(t, g1)
+	rowsRead, err = newScanner(stmt, &g1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, fakeStruct{}, g1[0])
+	assert.Equal(t, fakeStruct{}, g1[1])
+	iter.Reset()
+
+	// Test decoding into a struct with no fields
+	type emptyStruct struct{}
+	var h1 []emptyStruct
+	assert.Nil(t, h1)
+	rowsRead, err = newScanner(stmt, &h1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rowsRead)
+	assert.Equal(t, emptyStruct{}, h1[0])
+	assert.Equal(t, emptyStruct{}, h1[1])
+	iter.Reset()
+
+	// Test decoding into a struct with invalid types panics
+	type badStruct struct {
+		ID   int64
+		Name int32
+	}
+	var i1 []badStruct
+	assert.Nil(t, i1)
+	assert.Panics(t, func() { newScanner(stmt, &i1).ScanIter(iter) })
+	iter.Reset()
+}
+
+func TestScanIterStruct(t *testing.T) {
+	results := []map[string]interface{}{
+		{"id": "acc_abcd1", "name": "John", "created": "2018-05-01 19:00:00+0000"},
+		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
+	}
+
+	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "created"})
+	iter := newMockIterator(results, stmt.FieldNames())
+
+	expected := []account{
+		{ID: "acc_abcd1", Name: "John"},
+		{ID: "acc_abcd2", Name: "Jane"},
+	}
+
+	// Test with decoding into a struct
+	a1 := account{}
+	rowsRead, err := newScanner(stmt, &a1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	assert.Equal(t, expected[0], a1)
+	iter.Reset()
+
+	// Test decoding into a pointer of pointer to struct
+	b1 := &account{}
+	rowsRead, err = newScanner(stmt, &b1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	assert.Equal(t, expected[0], *b1)
+	iter.Reset()
+
+	// Test decoding into a nil struct
+	var c1 *account
+	assert.Nil(t, c1)
+	rowsRead, err = newScanner(stmt, &c1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	assert.Equal(t, expected[0], *c1)
+	iter.Reset()
+
+	// Test decoding into a pointer of pointer of pointer to struct
+	var d1 **account
+	assert.Nil(t, d1)
+	rowsRead, err = newScanner(stmt, &d1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	assert.Equal(t, expected[0], **d1)
+	iter.Reset()
+
+	// Test with multiple scans into different structs
+	var e1 *account
+	var e2 ****account
+	rowsRead, err = newScanner(stmt, &e1).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	rowsRead, err = newScanner(stmt, &e2).ScanIter(iter)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rowsRead)
+	assert.Equal(t, expected[0], *e1)
+	assert.Equal(t, expected[1], ****e2)
+	iter.Reset()
+
+	// Test for row not found
+	var f1 *account
+	noResultsIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
+	rowsRead, err = newScanner(stmt, &f1).ScanIter(noResultsIter)
+	assert.EqualError(t, err, ":0: No rows returned")
+}
+
+func TestAllocateNilReference(t *testing.T) {
+	// Test non pointer, should do nothing
+	var a string
+	assert.Equal(t, "", a)
+	assert.False(t, allocateNilReference(a))
+	assert.Equal(t, "", a)
+
+	// Test pointer which hasn't been passed in by reference, should panic
+	var b *string
+	assert.Nil(t, b)
+	assert.Panics(t, func() { allocateNilReference(b) })
+
+	// Test pointer which is passed in by ref
+	assert.Nil(t, b)
+	assert.True(t, allocateNilReference(&b))
+	assert.Equal(t, "", *b)
+
+	// Test with a struct
+	type test struct{}
+	var c *test
+	assert.Nil(t, c)
+	assert.True(t, allocateNilReference(&c))
+	assert.Equal(t, test{}, *c)
+
+	// Test with a slice
+	var d *[]test
+	assert.Nil(t, d)
+	assert.True(t, allocateNilReference(&d))
+	assert.Equal(t, []test{}, *d)
+
+	// Test with a slice of pointers
+	var e *[]*test
+	assert.Nil(t, e)
+	assert.True(t, allocateNilReference(&e))
+	assert.Equal(t, []*test{}, *e)
+
+	// Test with a map
+	var f map[string]test
+	assert.Nil(t, f)
+	assert.True(t, allocateNilReference(&f))
+	assert.Equal(t, map[string]test{}, f)
+
+	// Test with an allocated struct, it should just return
+	g := []*test{}
+	ref := &g
+	assert.False(t, allocateNilReference(&g))
+	assert.Equal(t, ref, &g)
+}
+
+func TestGetNonPtrType(t *testing.T) {
+	var a int
+	assert.Equal(t, reflect.TypeOf(int(0)), getNonPtrType(reflect.TypeOf(a)))
+	assert.Equal(t, reflect.TypeOf(int(0)), getNonPtrType(reflect.TypeOf(&a)))
+
+	var b *int
+	assert.Equal(t, reflect.TypeOf(int(0)), getNonPtrType(reflect.TypeOf(&b)))
+
+	var c []*int
+	assert.Equal(t, reflect.TypeOf([]*int{}), getNonPtrType(reflect.TypeOf(c)))
+	assert.Equal(t, reflect.TypeOf([]*int{}), getNonPtrType(reflect.TypeOf(&c)))
+}
+
+func TestWrapPtrValue(t *testing.T) {
+	// Test with no pointers, should do nothing
+	a := reflect.ValueOf("")
+	assert.Equal(t, string(""), wrapPtrValue(a, reflect.TypeOf("")).String())
+
+	// Go ham with a double pointer
+	var s **string
+	targetType := reflect.TypeOf(s)
+	assert.Equal(t, string(""), wrapPtrValue(a, targetType).Elem().Elem().String())
+}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -242,49 +242,49 @@ func TestAllocateNilReference(t *testing.T) {
 	// Test non pointer, should do nothing
 	var a string
 	assert.Equal(t, "", a)
-	assert.False(t, allocateNilReference(a))
+	assert.NoError(t, allocateNilReference(a))
 	assert.Equal(t, "", a)
 
-	// Test pointer which hasn't been passed in by reference, should panic
+	// Test pointer which hasn't been passed in by reference, should err
 	var b *string
 	assert.Nil(t, b)
-	assert.Panics(t, func() { allocateNilReference(b) })
+	assert.Error(t, allocateNilReference(b))
 
 	// Test pointer which is passed in by ref
 	assert.Nil(t, b)
-	assert.True(t, allocateNilReference(&b))
+	assert.NoError(t, allocateNilReference(&b))
 	assert.Equal(t, "", *b)
 
 	// Test with a struct
 	type test struct{}
 	var c *test
 	assert.Nil(t, c)
-	assert.True(t, allocateNilReference(&c))
+	assert.NoError(t, allocateNilReference(&c))
 	assert.Equal(t, test{}, *c)
 
 	// Test with a slice
 	var d *[]test
 	assert.Nil(t, d)
-	assert.True(t, allocateNilReference(&d))
+	assert.NoError(t, allocateNilReference(&d))
 	assert.Equal(t, []test{}, *d)
 
 	// Test with a slice of pointers
 	var e *[]*test
 	assert.Nil(t, e)
-	assert.True(t, allocateNilReference(&e))
+	assert.NoError(t, allocateNilReference(&e))
 	assert.Equal(t, []*test{}, *e)
 
 	// Test with a map
 	var f map[string]test
 	assert.Nil(t, f)
-	assert.True(t, allocateNilReference(&f))
+	assert.NoError(t, allocateNilReference(&f))
 	assert.Equal(t, map[string]test{}, f)
 
 	// Test with an allocated struct, it should just return
 	g := []*test{}
 	ref := &g
-	assert.False(t, allocateNilReference(&g))
-	assert.Equal(t, ref, &g)
+	assert.NoError(t, allocateNilReference(&g))
+	assert.True(t, &g == ref) // These should be the same pointer
 }
 
 func TestGetNonPtrType(t *testing.T) {

--- a/statement.go
+++ b/statement.go
@@ -1,0 +1,42 @@
+package gocassa
+
+type statement struct {
+	columns []string
+	values  []interface{}
+	query   string
+}
+
+var noOpStatement = newStatement("", []interface{}{})
+
+// ColumnNames contains the column names which will be selected
+// This will only be populated for SELECT queries
+func (s statement) ColumnNames() []string {
+	return s.columns
+}
+
+// Values encapsulates binding values to be set within the CQL
+// query string as binding parameters. If there are no binding
+// parameters in the query, this will be the empty slice
+func (s statement) Values() []interface{} {
+	return s.values
+}
+
+// Query returns the CQL query for this statement
+func (s statement) Query() string {
+	return s.query
+}
+
+func newStatement(query string, values []interface{}) statement {
+	return statement{
+		query:  query,
+		values: values,
+	}
+}
+
+func newSelectStatement(query string, values []interface{}, columnNames []string) statement {
+	return statement{
+		query:   query,
+		values:  values,
+		columns: columnNames,
+	}
+}

--- a/statement.go
+++ b/statement.go
@@ -1,17 +1,28 @@
 package gocassa
 
+import "reflect"
+
 type statement struct {
-	columns []string
-	values  []interface{}
-	query   string
+	fieldNames []string
+	fieldTypes []reflect.Type
+
+	values []interface{}
+	query  string
 }
 
 var noOpStatement = newStatement("", []interface{}{})
 
-// ColumnNames contains the column names which will be selected
+// FieldNames contains the column names which will be selected
 // This will only be populated for SELECT queries
-func (s statement) ColumnNames() []string {
-	return s.columns
+func (s statement) FieldNames() []string {
+	return s.fieldNames
+}
+
+// FieldTypes contains the binding types of columns selected
+// in their referenced struct. This will only be populated for
+// SELECT queries
+func (s statement) FieldTypes() []reflect.Type {
+	return s.fieldTypes
 }
 
 // Values encapsulates binding values to be set within the CQL
@@ -33,10 +44,11 @@ func newStatement(query string, values []interface{}) statement {
 	}
 }
 
-func newSelectStatement(query string, values []interface{}, columnNames []string) statement {
+func newSelectStatement(query string, values []interface{}, fieldNames []string, fieldTypes []reflect.Type) statement {
 	return statement{
-		query:   query,
-		values:  values,
-		columns: columnNames,
+		query:      query,
+		values:     values,
+		fieldNames: fieldNames,
+		fieldTypes: fieldTypes,
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -1,10 +1,7 @@
 package gocassa
 
-import "reflect"
-
 type statement struct {
 	fieldNames []string
-	fieldTypes []reflect.Type
 
 	values []interface{}
 	query  string
@@ -16,13 +13,6 @@ var noOpStatement = newStatement("", []interface{}{})
 // This will only be populated for SELECT queries
 func (s statement) FieldNames() []string {
 	return s.fieldNames
-}
-
-// FieldTypes contains the binding types of columns selected
-// in their referenced struct. This will only be populated for
-// SELECT queries
-func (s statement) FieldTypes() []reflect.Type {
-	return s.fieldTypes
 }
 
 // Values encapsulates binding values to be set within the CQL
@@ -44,11 +34,10 @@ func newStatement(query string, values []interface{}) statement {
 	}
 }
 
-func newSelectStatement(query string, values []interface{}, fieldNames []string, fieldTypes []reflect.Type) statement {
+func newSelectStatement(query string, values []interface{}, fieldNames []string) statement {
 	return statement{
 		query:      query,
 		values:     values,
 		fieldNames: fieldNames,
-		fieldTypes: fieldTypes,
 	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,0 +1,43 @@
+package gocassa
+
+import (
+	"testing"
+)
+
+func TestStatement(t *testing.T) {
+	query1 := "DROP KEYSPACE IF EXISTS fakekeyspace"
+	stmtPlain := newStatement(query1, []interface{}{})
+	if stmtPlain.Query() != query1 {
+		t.Fatalf("expected query '%s', got '%s'", query1, stmtPlain.Query())
+	}
+	if len(stmtPlain.FieldNames()) != 0 {
+		t.Fatalf("expected 0 fields, got %d fields", len(stmtPlain.FieldNames()))
+	}
+	if len(stmtPlain.Values()) != 0 {
+		t.Fatalf("expected 0 values, got %d values", len(stmtPlain.FieldNames()))
+	}
+
+	query2 := "DELETE FROM fakekeyspace.faketable WHERE id = ?"
+	stmtWithValues := newStatement(query2, []interface{}{"id_abcd1234"})
+	if stmtWithValues.Query() != query2 {
+		t.Fatalf("expected query '%s', got '%s'", query2, stmtWithValues.Query())
+	}
+	if len(stmtWithValues.FieldNames()) != 0 {
+		t.Fatalf("expected 0 fields, got %d fields", len(stmtWithValues.FieldNames()))
+	}
+	if len(stmtWithValues.Values()) != 1 {
+		t.Fatalf("expected 1 value, got %d values", len(stmtWithValues.FieldNames()))
+	}
+
+	query3 := "SELECT id, name, created FROM fakekeyspace.faketable WHERE id = ?"
+	stmtSelect := newSelectStatement(query3, []interface{}{"id_abcd1234"}, []string{"id", "name", "created"})
+	if stmtSelect.Query() != query3 {
+		t.Fatalf("expected query '%s', got '%s'", query3, stmtSelect.Query())
+	}
+	if len(stmtSelect.FieldNames()) != 3 {
+		t.Fatalf("expected 3 fields, got %d fields", len(stmtSelect.FieldNames()))
+	}
+	if len(stmtSelect.Values()) != 1 {
+		t.Fatalf("expected 1 value, got %d values", len(stmtSelect.FieldNames()))
+	}
+}

--- a/table.go
+++ b/table.go
@@ -79,7 +79,7 @@ func (t t) Where(rs ...Relation) Filter {
 	}
 }
 
-func (t t) generateFieldNames(sel []string) string {
+func (t t) generateColumnFieldList(sel []string) []string {
 	xs := make([]string, len(t.info.fields))
 	if len(sel) > 0 {
 		xs = sel
@@ -88,7 +88,7 @@ func (t t) generateFieldNames(sel []string) string {
 			xs[i] = strings.ToLower(v)
 		}
 	}
-	return strings.Join(xs, ", ")
+	return xs
 }
 
 func relations(keys Keys, m map[string]interface{}) []Relation {
@@ -201,7 +201,7 @@ func (t t) Recreate() error {
 	return t.Create()
 }
 
-func (t t) CreateStatement() (string, error) {
+func (t t) CreateStatement() (Statement, error) {
 	return createTable(t.keySpace.name,
 		t.Name(),
 		t.info.keys.PartitionKeys,
@@ -215,7 +215,7 @@ func (t t) CreateStatement() (string, error) {
 	)
 }
 
-func (t t) CreateIfNotExistStatement() (string, error) {
+func (t t) CreateIfNotExistStatement() (Statement, error) {
 	return createTableIfNotExist(t.keySpace.name,
 		t.Name(),
 		t.info.keys.PartitionKeys,

--- a/table.go
+++ b/table.go
@@ -3,7 +3,6 @@ package gocassa
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -18,14 +17,13 @@ type t struct {
 
 // Contains mostly analyzed information about the entity
 type tableInfo struct {
-	keyspace, name     string
-	marshalSource      interface{}
-	fieldSource        map[string]interface{}
-	loweredFieldSource map[string]interface{} // Same as above but with lower case keys
-	keys               Keys
-	fieldNames         map[string]struct{} // This is here only to check containment
-	fields             []string
-	fieldValues        []interface{}
+	keyspace, name string
+	marshalSource  interface{}
+	fieldSource    map[string]interface{}
+	keys           Keys
+	fieldNames     map[string]struct{} // This is here only to check containment
+	fields         []string
+	fieldValues    []interface{}
 }
 
 func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSource map[string]interface{}) *tableInfo {
@@ -38,11 +36,9 @@ func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSou
 	}
 	fields := make([]string, 0, len(fieldSource))
 	values := make([]interface{}, 0, len(fieldSource))
-	loweredFieldSource := map[string]interface{}{}
 	for _, k := range sortedKeys(fieldSource) {
 		fields = append(fields, k)
 		values = append(values, fieldSource[k])
-		loweredFieldSource[strings.ToLower(k)] = fieldSource[k]
 	}
 	cinf.fieldNames = map[string]struct{}{}
 	for _, v := range fields {
@@ -50,7 +46,6 @@ func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSou
 	}
 	cinf.fields = fields
 	cinf.fieldValues = values
-	cinf.loweredFieldSource = loweredFieldSource
 	return cinf
 }
 
@@ -94,20 +89,6 @@ func (t t) generateFieldList(sel []string) []string {
 		}
 	}
 	return xs
-}
-
-// generateFieldTypes takes in the field names and returns
-// a slice of the associated types
-func (t t) generateFieldTypes(fieldNames []string) []reflect.Type {
-	ft := make([]reflect.Type, len(fieldNames))
-	for i, name := range fieldNames {
-		src, ok := t.info.loweredFieldSource[name]
-		if !ok {
-			panic(fmt.Sprintf("could not find field %s in %T", name, t.info.marshalSource))
-		}
-		ft[i] = reflect.TypeOf(src)
-	}
-	return ft
 }
 
 func relations(keys Keys, m map[string]interface{}) []Relation {

--- a/table_test.go
+++ b/table_test.go
@@ -274,13 +274,13 @@ type OptionCheckingQE struct {
 	opts *Options
 }
 
-func (qe OptionCheckingQE) QueryWithOptions(opts Options, stmt Statement) ([]map[string]interface{}, error) {
+func (qe OptionCheckingQE) QueryWithOptions(opts Options, stmt Statement, scanner Scanner) error {
 	qe.opts.Consistency = opts.Consistency
-	return []map[string]interface{}{}, nil
+	return nil
 }
 
-func (qe OptionCheckingQE) Query(stmt Statement) ([]map[string]interface{}, error) {
-	return qe.QueryWithOptions(Options{}, stmt)
+func (qe OptionCheckingQE) Query(stmt Statement, scanner Scanner) error {
+	return qe.QueryWithOptions(Options{}, stmt, scanner)
 }
 
 func (qe OptionCheckingQE) ExecuteWithOptions(opts Options, stmt Statement) error {

--- a/timeseries_table.go
+++ b/timeseries_table.go
@@ -13,13 +13,13 @@ type timeSeriesT struct {
 	bucketSize time.Duration
 }
 
-func (o *timeSeriesT) Table() Table                     { return o.t }
-func (o *timeSeriesT) Create() error                    { return o.Table().Create() }
-func (o *timeSeriesT) CreateIfNotExist() error          { return o.Table().CreateIfNotExist() }
-func (o *timeSeriesT) Name() string                     { return o.Table().Name() }
-func (o *timeSeriesT) Recreate() error                  { return o.Table().Recreate() }
-func (o *timeSeriesT) CreateStatement() (string, error) { return o.Table().CreateStatement() }
-func (o *timeSeriesT) CreateIfNotExistStatement() (string, error) {
+func (o *timeSeriesT) Table() Table                        { return o.t }
+func (o *timeSeriesT) Create() error                       { return o.Table().Create() }
+func (o *timeSeriesT) CreateIfNotExist() error             { return o.Table().CreateIfNotExist() }
+func (o *timeSeriesT) Name() string                        { return o.Table().Name() }
+func (o *timeSeriesT) Recreate() error                     { return o.Table().Recreate() }
+func (o *timeSeriesT) CreateStatement() (Statement, error) { return o.Table().CreateStatement() }
+func (o *timeSeriesT) CreateIfNotExistStatement() (Statement, error) {
 	return o.Table().CreateIfNotExistStatement()
 }
 


### PR DESCRIPTION
This PR replaces the use of the [`mapstructure`](https://github.com/mitchellh/mapstructure) library with custom reflection which is much more optimised for `gocassa` internals. Doing so leads to much more performant decoding characteristics. 

**⚠️ Given the extensive changes in the interface, this PR bumps the version of gocassa to v2.0.0**

### Motivation

The motivation for this PR came from profiling our services. Turns out quite a lot of services which use Cassandra at scale were spending 50-60%+ of their CPU within gocassa's `decodeResult` step (with a sizeable ~10% additionally spent in `MapScan`). This is a direct invocation of `mapstructure`.

Given I was going to tweak the interfaces, I took the liberty of cleaning up and adding a `Statement` object instead of ferrying around a query string and list of values. This can also encapsulate field name information under the hood which is used in our scanner.

### Change

This patch essentially hooks into the `gocql` Scanner directly rather than going through a map for `SELECT` queries. 

Previously we had two levels of reflection when reading via gocassa:
- A conversion from the Cassandra type into a `map[string]interface{}` within `gocql`. This used the `MapScan` function in `gocql` and thus results in a map per result allocated and populated
- A conversion using `decodeResult` in `gocassa` to convert each map into the target struct

Now we have a direct reflection into struct by leveraging the ordering of fields which gocassa also knows about since gocassa is what constructs the `SELECT` queries in the first place! 

### Benchmarks

**`gocassa` on `master`** (the benchmark test is at [`96f213d`](https://github.com/monzo/gocassa/commit/96f213d4c3a1993cd38011d32044771074c984ad)):
```
goos: darwin
goarch: amd64
pkg: github.com/monzo/gocassa
BenchmarkDecodeBlogSliceNoBody-4       	    3000	    480115 ns/op	   73486 B/op	    1687 allocs/op
BenchmarkDecodeBlogStruct-4            	     100	  12456151 ns/op	  375150 B/op	   30385 allocs/op
BenchmarkDecodeBlogStructEmptyBody-4   	  100000	     22711 ns/op	    3489 B/op	      68 allocs/op
BenchmarkDecodeAlphaSlice-4            	    1000	   1472692 ns/op	  306253 B/op	    5007 allocs/op
BenchmarkDecodeAlphaStruct-4           	   20000	     68542 ns/op	   14407 B/op	     174 allocs/op
PASS
ok  	github.com/monzo/gocassa	9.605s
```

These values are very high and it doesn't even account for the map allocation/population! I did some profiling and it turns out the [`DecodeHook` functionality we use](3fa24fca0346248338401cf2f93bdf938d55ae19) to convert from the `gocql` type of various integer types and also to support `UnmarshalCQL` functionality adds a very large overhead! I got rid of them briefly and ran another test.

**`gocassa` on `master` without DecodeHook functions** (the benchmark test is at [`96f213d`](https://github.com/monzo/gocassa/commit/96f213d4c3a1993cd38011d32044771074c984ad)):

```
goos: darwin
goarch: amd64
pkg: github.com/monzo/gocassa
BenchmarkDecodeBlogSliceNoBody-4       	   10000	    181272 ns/op	   73410 B/op	    1685 allocs/op
BenchmarkDecodeBlogStruct-4            	    1000	   1836223 ns/op	  374693 B/op	   30383 allocs/op
BenchmarkDecodeBlogStructEmptyBody-4   	  200000	      7485 ns/op	    3425 B/op	      66 allocs/op
BenchmarkDecodeAlphaSlice-4            	    2000	    720789 ns/op	  306197 B/op	    5005 allocs/op
BenchmarkDecodeAlphaStruct-4           	   50000	     35752 ns/op	   14339 B/op	     172 allocs/op
PASS
ok  	github.com/monzo/gocassa	10.730s
```

Still quite high but there has been noticeable improvement, especially in `BenchmarkDecodeBlogStruct` where decoding a single struct with a `[]byte` populated was making the per operation latency 9x slower. Note that we can't just get rid of these functions in real use because otherwise our integer types will be wrong. You don't even need to be using any of this functionality, just the conversion to execute these decode hooks adds a high amount of latency.

**`gocassa` with this PR on decoding into structs using the iterator directly:**
```
goos: darwin
goarch: amd64
pkg: github.com/monzo/gocassa
BenchmarkDecodeBlogSliceNoBody-4       	   50000	     34113 ns/op	   21280 B/op	     235 allocs/op
BenchmarkDecodeBlogStruct-4            	  500000	      3403 ns/op	    2784 B/op	      32 allocs/op
BenchmarkDecodeBlogStructEmptyBody-4   	  500000	      3281 ns/op	    2784 B/op	      32 allocs/op
BenchmarkDecodeAlphaSlice-4            	   10000	    103263 ns/op	   43836 B/op	     810 allocs/op
BenchmarkDecodeAlphaStruct-4           	  200000	      9768 ns/op	    9019 B/op	      92 allocs/op
PASS
ok  	github.com/monzo/gocassa	9.222s
```

This is a 5-10x+ improvement in latency per operation and significantly reduced memory allocations by hooking into gocql directly. If you are using byte slices or other similar data structures within your target unmarshal struct, the improvement will be massive (upwards of hundreds of times faster). 

```
benchmark                                old ns/op     new ns/op     delta
BenchmarkDecodeBlogSliceNoBody-4         480115        34113         -92.89%
BenchmarkDecodeBlogStruct-4              12456151      3403          -99.97%
BenchmarkDecodeBlogStructEmptyBody-4     22711         3281          -85.55%
BenchmarkDecodeAlphaSlice-4              1472692       103263        -92.99%
BenchmarkDecodeAlphaStruct-4             68542         9768          -85.75%

benchmark                                old allocs     new allocs     delta
BenchmarkDecodeBlogSliceNoBody-4         1687           235            -86.07%
BenchmarkDecodeBlogStruct-4              30385          32             -99.89%
BenchmarkDecodeBlogStructEmptyBody-4     68             32             -52.94%
BenchmarkDecodeAlphaSlice-4              5007           810            -83.82%
BenchmarkDecodeAlphaStruct-4             174            92             -47.13%

benchmark                                old bytes     new bytes     delta
BenchmarkDecodeBlogSliceNoBody-4         73486         21280         -71.04%
BenchmarkDecodeBlogStruct-4              375150        2784          -99.26%
BenchmarkDecodeBlogStructEmptyBody-4     3489          2784          -20.21%
BenchmarkDecodeAlphaSlice-4              306253        43836         -85.69%
BenchmarkDecodeAlphaStruct-4             14407         9019          -37.40%
```

This PR isn't adding any additional hidden work on the `gocql` side because this iteration cost is already being spent by using `MapScan` which does the same work (in fact, as of writing this, it uses the `gocql.Iter.Scan()` under the hood).