### PR TITLE
😨 gocql errors should not always be treated as RowNotFound errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v2.0.1 - 2019-06-28
+
+### Changed
+ - Scannable has been expanded to take in a gocql Scannable. This is so the error handling can be greatly improved
+
+### Fixed
+ - Fixed issue masking all gocql iterator errors as RowNotFound when reading a single row
+
 ## v2.0.0 - 2019-06-22
 
 *Note*: This is a major version change and quite a lot of the internals have changed to make decoding substantially faster. You will need to make some tweaks to your code if you are upgrading from v1. Please see the updated `interfaces.go` and the example in `gocql_backend.go` for updated usage.

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package gocassa is a high-level library on top of gocql
 //
-// Current version: v2.0.0
+// Current version: v2.0.1
 // Compared to gocql it provides query building, adds data binding, and provides
 // easy-to-use "recipe" tables for common query use-cases. Unlike cqlc, it does
 // not use code generation.

--- a/gocql_backend.go
+++ b/gocql_backend.go
@@ -19,8 +19,7 @@ func (cb goCQLBackend) QueryWithOptions(opts Options, stmt Statement, scanner Sc
 	}
 
 	iter := qu.Iter()
-	if _, err := scanner.ScanIter(iter); err != nil {
-		iter.Close() // try and close the iterator to release any resources
+	if _, err := scanner.ScanIter(iter.Scanner()); err != nil {
 		return err
 	}
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -270,9 +270,25 @@ type Statement interface {
 	Query() string
 }
 
-// Scannable is an interface Matches the iter.Scan method found in GoCQL
+// Scannable is an interface which matches the interface found in
+// GoCQL Scannable
 type Scannable interface {
-	Scan(dest ...interface{}) bool
+	// Next advances the row pointer to point at the next row, the row is valid until
+	// the next call of Next. It returns true if there is a row which is available to be
+	// scanned into with Scan.
+	// Next must be called before every call to Scan.
+	Next() bool
+
+	// Scan copies the current row's columns into dest. If the length of dest does not equal
+	// the number of columns returned in the row an error is returned. If an error is encountered
+	// when unmarshalling a column into the value in dest an error is returned and the row is invalidated
+	// until the next call to Next.
+	// Next must be called before calling Scan, if it is not an error is returned.
+	Scan(dest ...interface{}) error
+
+	// Err returns the if there was one during iteration that resulted in iteration being unable to complete.
+	// Err will also release resources held by the iterator, the Scanner should not used after being called.
+	Err() error
 }
 
 // Scanner encapsulates a scanner which scans rows from a GoCQL iterator.

--- a/scanner.go
+++ b/scanner.go
@@ -112,8 +112,7 @@ func (s *scanner) iterSingle(iter Scannable) (int, error) {
 	}
 
 	ptrs := generatePtrs(structFields)
-	ok := iter.Next()
-	if !ok {
+	if !iter.Next() {
 		err := iter.Err()
 		if err == nil || err == gocql.ErrNotFound {
 			return 0, RowNotFoundError{}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -111,7 +111,8 @@ func TestScanIterSlice(t *testing.T) {
 	}
 	var i1 []badStruct
 	assert.Nil(t, i1)
-	assert.Panics(t, func() { newScanner(stmt, &i1).ScanIter(iter) })
+	_, err = newScanner(stmt, &i1).ScanIter(iter)
+	assert.Error(t, err)
 	iter.Reset()
 }
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -182,6 +183,16 @@ func TestScanIterStruct(t *testing.T) {
 	noResultsIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
 	rowsRead, err = newScanner(stmt, &f1).ScanIter(noResultsIter)
 	assert.EqualError(t, err, ":0: No rows returned")
+
+	// Test for a non-rows-not-found error
+	var g1 *Account
+	errorerIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
+	errorScanner := newScanner(stmt, &g1)
+	expectedErr := fmt.Errorf("Something went baaaad")
+	errorerIter.err = expectedErr
+	rowsRead, err = errorScanner.ScanIter(errorerIter)
+	assert.Equal(t, 0, rowsRead)
+	assert.Equal(t, err, expectedErr)
 }
 
 func TestScanIterComposite(t *testing.T) {


### PR DESCRIPTION
Previously, we were treating a failed loop of the iterator as a `RowNotFound` error. This fixes that by actually looking at the error and acting appropriately. 

The `Scannable` interface has had to be added to so it's basically a `gocql.Scanner` which is fine as the two now intermingle and we can add appropriate testing in our mocks.