### PR TITLE
🗞️ Only allocate pointers when we are ready to set/use the result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v2.0.2 - 2019-07-01
+
+### Fixed
+ - If an error is thrown whilst scanning/reading a single row, the original pointer will stay untouched (previously it may have been allocated with the initial value of your struct)
+
 ## v2.0.1 - 2019-06-28
 
 ### Changed

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package gocassa is a high-level library on top of gocql
 //
-// Current version: v2.0.1
+// Current version: v2.0.2
 // Compared to gocql it provides query building, adds data binding, and provides
 // easy-to-use "recipe" tables for common query use-cases. Unlike cqlc, it does
 // not use code generation.

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -183,6 +183,7 @@ func TestScanIterStruct(t *testing.T) {
 	noResultsIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
 	rowsRead, err = newScanner(stmt, &f1).ScanIter(noResultsIter)
 	assert.EqualError(t, err, ":0: No rows returned")
+	assert.Nil(t, f1)
 
 	// Test for a non-rows-not-found error
 	var g1 *Account
@@ -193,6 +194,7 @@ func TestScanIterStruct(t *testing.T) {
 	rowsRead, err = errorScanner.ScanIter(errorerIter)
 	assert.Equal(t, 0, rowsRead)
 	assert.Equal(t, err, expectedErr)
+	assert.Nil(t, g1)
 }
 
 func TestScanIterComposite(t *testing.T) {


### PR DESCRIPTION
If you pass a pointer to an address that is nil, we do some allocation. Right now this happens at the top of the function so we don't have to worry about it.

This PR changes that behaviour slightly to allocate right before we are ready to set (and after some errors have been handled). In gocassa v2.0.0, this behaviour was undefined but there are users who were relying on the result value/pointer being untouched (unallocated in the nil case) in the case of an error. Also adds a test to make sure we don't have a future regression.