### PR TITLE
Add support for blob types in primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v2.0.2 - 2019-06-28
+
+### Fixed
+ - Fix blob types in primary keys not being comparable
+
 ## v2.0.1 - 2019-06-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gocassa
 
 Gocassa is a high-level library on top of [gocql](https://github.com/gocql/gocql).
 
-Current version: v2.0.0
+Current version: v2.0.2
 
 Compared to gocql it provides query building, adds data binding, and provides easy-to-use "recipe" tables for common query use-cases. Unlike [cqlc](https://github.com/relops/cqlc), it does not use code generation.
 

--- a/relation.go
+++ b/relation.go
@@ -56,6 +56,16 @@ func convertToPrimitive(i interface{}) interface{} {
 		return v.UnixNano()
 	case time.Duration:
 		return v.Nanoseconds()
+	case []byte:
+		// This case works as strings in Go are simply defined as the following:
+		// "A string value is a (possibly empty) sequence of bytes" (from the go lang spec)
+		// and
+		// "Converting a slice of bytes to a string type yields a string whose successive bytes are the elements of the slice."
+		// Finally:
+		// "String values are comparable and ordered, lexically byte-wise."
+		// We mostly want this to allow comparisons of blob types in the primary key of a table,
+		// since []byte are not `==` comparable in go, but strings are
+		return string(v)
 	default:
 		return i
 	}

--- a/relation_test.go
+++ b/relation_test.go
@@ -18,6 +18,7 @@ func TestAnyEquals(t *testing.T) {
 		{time.Minute * 2, makeInterfaceArray(time.Second * 120)},
 		{testTime1, makeInterfaceArray(testTime2)},
 		{1950, makeInterfaceArray(1950)},
+		{[]byte{0x00, 0xFF, 0x01, 0x99, 0xEA}, makeInterfaceArray("\x00\xFF\x01\x99\xEA")},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We found a case where a mock keyspace in tests would panic when there was a blob column in the primary key of a table while writing tests for #31873
`panic: runtime error: comparing uncomparable type []uint8`
The line panicing seemed to be this one:
https://github.com/monzo/gocassa/blob/ef231cad77826485d5858060ccee5e4c89cd4d36/relation.go#L46

This seems to be a limitation in gocassa as it attempts to compare two `[]byte` variables wrapped in `{}interface`, which Go doesn't allow. This ends up panicing the runtime.

The solution proposed and implemented in this PR is based on the fact that go `[]byte` slices can be cast to `string` without changing the bytes in the slice, even if that results in an invalid utf-8 sequence (go deals with this at runtime when parsing the string for rendering).
As stated in the linked blog post https://blog.golang.org/strings:
> It's important to state right up front that a string holds arbitrary bytes

Quoting the Go lang spec:
> A string value is a (possibly empty) sequence of bytes

and
>Converting a slice of bytes to a string type yields a string whose successive bytes are the elements of the slice.

Finally and relevant to this specific piece of code and how it's used in the surrounding code:
> String values are comparable and ordered, lexically byte-wise.
