### PR TITLE
🆎 Support proxy types in mock implementation for comparison

### DIFF
--- a/relation.go
+++ b/relation.go
@@ -1,6 +1,8 @@
 package gocassa
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -67,6 +69,11 @@ func convertToPrimitive(i interface{}) interface{} {
 		// since []byte are not `==` comparable in go, but strings are
 		return string(v)
 	default:
+		// If the underlying type is a string, we want to represent this value
+		// as a string for comparison across proxy types.
+		if reflect.ValueOf(i).Kind() == reflect.String {
+			return fmt.Sprintf("%v", i)
+		}
 		return i
 	}
 }

--- a/relation_test.go
+++ b/relation_test.go
@@ -11,6 +11,8 @@ func TestAnyEquals(t *testing.T) {
 	testTime1, _ := time.ParseInLocation(time.RFC3339, "2013-08-05T09:00:00+01:00", loc1)
 	testTime2, _ := time.ParseInLocation(time.RFC3339, "2013-08-05T08:00:00Z", loc2)
 
+	type name string
+
 	testCases := []struct {
 		term      interface{}
 		relations []interface{}
@@ -19,12 +21,13 @@ func TestAnyEquals(t *testing.T) {
 		{testTime1, makeInterfaceArray(testTime2)},
 		{1950, makeInterfaceArray(1950)},
 		{[]byte{0x00, 0xFF, 0x01, 0x99, 0xEA}, makeInterfaceArray("\x00\xFF\x01\x99\xEA")},
+		{name("Bingo 🐕"), makeInterfaceArray("Bingo 🐕")},
 	}
 
 	for _, tc := range testCases {
 		equality := anyEquals(tc.term, tc.relations)
 		if !equality {
-			t.Fatal("not equal")
+			t.Fatalf("not equal (testcase: %v)", tc)
 		}
 	}
 }


### PR DESCRIPTION
If you passed in a type which was a proxy for `string`, it'd still fail the type conversion test. This makes sure we can handle it