### PR TITLE
🤞 Use OpenJDK for Travis tests and include Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,17 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - tip
 
 addons:
   apt:
    packages:
-    - oracle-java8-installer
+    - openjdk-8-jdk-headless
 
 before_install:
-  - sudo update-java-alternatives -s java-8-oracle
-  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+  - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+  - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version
   - sudo rm -rf /var/lib/cassandra/*
   - wget https://archive.apache.org/dist/cassandra/3.0.16/apache-cassandra-3.0.16-bin.tar.gz && tar -xvzf apache-cassandra-3.0.16-bin.tar.gz


### PR DESCRIPTION
Fixes the tests so they actually run on Travis (the Oracle package gives us nothing fancy in tests and is a pain to install.

Also enables Go 1.13