### PR TITLE
Rename RunAtomically to RunLoggedBatch

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -25,13 +25,14 @@ func (r RowNotFoundError) Error() string {
 // in a multiOp scenario)
 type errOp struct{ err error }
 
-func (o errOp) Run() error                                       { return o.err }
-func (o errOp) RunWithContext(_ context.Context) error           { return o.err }
-func (o errOp) RunAtomically() error                             { return o.err }
-func (o errOp) RunAtomicallyWithContext(_ context.Context) error { return o.err }
-func (o errOp) Add(ops ...Op) Op                                 { return multiOp{o}.Add(ops...) }
-func (o errOp) Options() Options                                 { return Options{} }
-func (o errOp) WithOptions(_ Options) Op                         { return o }
-func (o errOp) Preflight() error                                 { return o.err }
-func (o errOp) GenerateStatement() Statement                     { return noOpStatement }
-func (o errOp) QueryExecutor() QueryExecutor                     { return nil }
+func (o errOp) Run() error                                        { return o.err }
+func (o errOp) RunWithContext(_ context.Context) error            { return o.err }
+func (o errOp) RunAtomically() error                              { return o.err }
+func (o errOp) RunAtomicallyWithContext(_ context.Context) error  { return o.err }
+func (o errOp) RunLoggedBatchWithContext(_ context.Context) error { return o.err }
+func (o errOp) Add(ops ...Op) Op                                  { return multiOp{o}.Add(ops...) }
+func (o errOp) Options() Options                                  { return Options{} }
+func (o errOp) WithOptions(_ Options) Op                          { return o }
+func (o errOp) Preflight() error                                  { return o.err }
+func (o errOp) GenerateStatement() Statement                      { return noOpStatement }
+func (o errOp) QueryExecutor() QueryExecutor                      { return nil }

--- a/interfaces.go
+++ b/interfaces.go
@@ -250,10 +250,16 @@ type Op interface {
 	Run() error
 	// RunWithContext runs the operation, providing context to the executor.
 	RunWithContext(context.Context) error
-	// You do not need this in 95% of the use cases, use Run!
-	// Using atomic batched writes (logged batches in Cassandra terminology) comes at a high performance cost!
+
+	// Run the operation as a logged batch. This provides some atomicity guarantees (all writes will complete,
+	// or none at all) but not all (it does not provide isolation, for example)
+	//
+	// This comes at a performance cost
+	RunLoggedBatchWithContext(context.Context) error
+
+	// Deprecated: The name "RunAtomically" is a misnomer, and "RunLoggedBatchWithContext" should be used instead
 	RunAtomically() error
-	// Run the operation as an atomic (logged) batch, providing context to the executor.
+	// Deprecated: The name "RunAtomically" is a misnomer, and "RunLoggedBatchWithContext" should be used instead
 	RunAtomicallyWithContext(context.Context) error
 	// Add an other Op to this one.
 	Add(...Op) Op
@@ -270,7 +276,7 @@ type Op interface {
 	// Options lets you read the `Options` for this `Op`
 	Options() Options
 	// Preflight performs any pre-execution validation that confirms the op considers itself "valid".
-	// NOTE: Run() and RunAtomically() should call this method before execution, and abort if any errors are returned.
+	// NOTE: Run() and RunLoggedBatch() should call this method before execution, and abort if any errors are returned.
 	Preflight() error
 	// GenerateStatement generates the statement to perform the operation
 	GenerateStatement() Statement

--- a/mock.go
+++ b/mock.go
@@ -64,8 +64,12 @@ func (m mockOp) RunAtomically() error {
 	return m.Run()
 }
 
-func (m mockOp) RunAtomicallyWithContext(ctx context.Context) error {
+func (m mockOp) RunLoggedBatchWithContext(ctx context.Context) error {
 	return m.WithOptions(Options{Context: ctx}).Run()
+}
+
+func (m mockOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return m.RunLoggedBatchWithContext(ctx)
 }
 
 func (m mockOp) GenerateStatement() Statement {
@@ -102,8 +106,12 @@ func (mo mockMultiOp) RunAtomically() error {
 	return mo.Run()
 }
 
-func (mo mockMultiOp) RunAtomicallyWithContext(ctx context.Context) error {
+func (mo mockMultiOp) RunLoggedBatchWithContext(ctx context.Context) error {
 	return mo.WithOptions(Options{Context: ctx}).Run()
+}
+
+func (mo mockMultiOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return mo.RunLoggedBatchWithContext(ctx)
 }
 
 func (mo mockMultiOp) GenerateStatement() Statement {

--- a/mock_test.go
+++ b/mock_test.go
@@ -169,7 +169,7 @@ func (s *MockSuite) TestTableRead() {
 	s.Equal(u4, u)
 
 	s.NoError(op1.Add(op2).Run())
-	s.NoError(op1.Add(op2).RunAtomically())
+	s.NoError(op1.Add(op2).RunLoggedBatchWithContext(context.Background()))
 }
 
 func (s *MockSuite) TestTableUpdate() {

--- a/multiop.go
+++ b/multiop.go
@@ -24,7 +24,7 @@ func (mo multiOp) RunWithContext(ctx context.Context) error {
 	return mo.WithOptions(Options{Context: ctx}).Run()
 }
 
-func (mo multiOp) RunAtomically() error {
+func (mo multiOp) runLoggedBatch() error {
 	if len(mo) == 0 {
 		return nil
 	}
@@ -42,8 +42,16 @@ func (mo multiOp) RunAtomically() error {
 	return qe.ExecuteAtomicallyWithOptions(mo.Options(), stmts)
 }
 
-func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
+func (mo multiOp) RunLoggedBatchWithContext(ctx context.Context) error {
 	return mo.WithOptions(Options{Context: ctx}).RunAtomically()
+}
+
+func (mo multiOp) RunAtomically() error {
+	return mo.runLoggedBatch()
+}
+
+func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return mo.RunLoggedBatchWithContext(ctx)
 }
 
 func (mo multiOp) GenerateStatement() Statement {

--- a/op.go
+++ b/op.go
@@ -94,8 +94,12 @@ func (o *singleOp) RunAtomically() error {
 	return o.Run()
 }
 
-func (o *singleOp) RunAtomicallyWithContext(ctx context.Context) error {
+func (o *singleOp) RunLoggedBatchWithContext(ctx context.Context) error {
 	return o.WithOptions(Options{Context: ctx}).Run()
+}
+
+func (o *singleOp) RunAtomicallyWithContext(ctx context.Context) error {
+	return o.RunLoggedBatchWithContext(ctx)
 }
 
 func (o *singleOp) GenerateStatement() Statement {

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package gocassa
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -113,7 +114,7 @@ func TestMultipleRowResults(t *testing.T) {
 	}
 }
 
-func TestRunAtomically(t *testing.T) {
+func TestRunLoggedBatch(t *testing.T) {
 	name := "customer_multipletest2"
 	cs := ns.Table(name, Customer{}, Keys{
 		PartitionKeys:     []string{"Name"},
@@ -129,7 +130,7 @@ func TestRunAtomically(t *testing.T) {
 	}).Add(cs.Set(Customer{
 		Id:   "13",
 		Name: "John",
-	})).RunAtomically()
+	})).RunLoggedBatchWithContext(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The name RunAtomically is misleading - it doesn't give atomicity in the
"traditional" sense. It doesn't provide isolation (so other readers may
observe inconsistent state), and it doesn't provide Read-Your-Writes
consistency. That is to say, assuming the following three operations are
the _only_ operations issued on the database:

 * A write with RunAtomically (which returns an error)
 * A read of the written row
 * A second read of the written row

In some failure cases, both reads may return different values (in
particular, the first read can observe the old value and the second read
the new value), even if all operations were to be performed at QUORUM
consistency

The name RunAtomically is therefore an attractive nuisance. The name
RunLoggedBatch - which takes its name from the underlying Cassandra
operation - means someone is much more likely to peruse the
documentation before attempting to use this Cassandra feature