### PR TITLE
Refactor generating CQL to Statement 🗣️

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -36,8 +36,9 @@ func BenchmarkDecodeBlogSliceNoBody(b *testing.B) {
 	for i := 0; i < 20; i++ {
 		results[i] = m
 	}
-	stmt := newSelectStatement("", []interface{}{}, fieldNames)
-	iter := newMockIterator(results, stmt.FieldNames())
+
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	for i := 0; i < b.N; i++ {
 		res := []blogPost{}
@@ -84,8 +85,8 @@ func benchmarkBlogPostSingle(b *testing.B, postData []byte) {
 
 	fieldNames := sortedKeys(m)
 	results := []map[string]interface{}{m}
-	stmt := newSelectStatement("", []interface{}{}, fieldNames)
-	iter := newMockIterator(results, stmt.FieldNames())
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	for i := 0; i < b.N; i++ {
 		res := blogPost{}
@@ -126,8 +127,8 @@ func BenchmarkDecodeAlphaSlice(b *testing.B) {
 	for i := 0; i < 20; i++ {
 		results[i] = m
 	}
-	stmt := newSelectStatement("", []interface{}{}, fieldNames)
-	iter := newMockIterator(results, stmt.FieldNames())
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	for i := 0; i < b.N; i++ {
 		res := []alphaStruct{}
@@ -158,8 +159,8 @@ func BenchmarkDecodeAlphaStruct(b *testing.B) {
 
 	fieldNames := sortedKeys(m)
 	results := []map[string]interface{}{m}
-	stmt := newSelectStatement("", []interface{}{}, fieldNames)
-	iter := newMockIterator(results, stmt.FieldNames())
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	for i := 0; i < b.N; i++ {
 		res := alphaStruct{}

--- a/bench_test.go
+++ b/bench_test.go
@@ -176,3 +176,18 @@ func BenchmarkDecodeAlphaStruct(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkStatementMapTable(b *testing.B) {
+	tbl := ns.MapTable("customer_bench", "Id", Customer{})
+
+	row := Customer{Id: "100", Name: "Joe"}
+	update := map[string]interface{}{"name": "Gary"}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tbl.Read(row.Id, nil).GenerateStatement()
+		tbl.Set(row).GenerateStatement()
+		tbl.Update(row.Id, update).GenerateStatement()
+		tbl.Delete(row.Id).GenerateStatement()
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -32,14 +32,14 @@ func NewConnection(q QueryExecutor) Connection {
 // CreateKeySpace creates a keyspace with the given name. Only used to create test keyspaces.
 func (c *connection) CreateKeySpace(name string) error {
 	query := fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };", name)
-	stmt := newStatement(query, []interface{}{})
+	stmt := cqlStatement{query: query}
 	return c.q.Execute(stmt)
 }
 
 // DropKeySpace drops the keyspace having the given name.
 func (c *connection) DropKeySpace(name string) error {
 	query := fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", name)
-	stmt := newStatement(query, []interface{}{})
+	stmt := cqlStatement{query: query}
 	return c.q.Execute(stmt)
 }
 

--- a/errors.go
+++ b/errors.go
@@ -34,5 +34,5 @@ func (o errOp) Add(ops ...Op) Op                                  { return multi
 func (o errOp) Options() Options                                  { return Options{} }
 func (o errOp) WithOptions(_ Options) Op                          { return o }
 func (o errOp) Preflight() error                                  { return o.err }
-func (o errOp) GenerateStatement() Statement                      { return noOpStatement }
+func (o errOp) GenerateStatement() Statement                      { return noOpStatement{} }
 func (o errOp) QueryExecutor() QueryExecutor                      { return nil }

--- a/generate.go
+++ b/generate.go
@@ -94,7 +94,7 @@ func createTableStmt(createStmt, keySpace, cf string, partitionKeys, colKeys []s
 
 	lines = append(lines, ";")
 	qry := strings.Join(lines, "\n")
-	return newStatement(qry, []interface{}{}), nil
+	return cqlStatement{query: qry}, nil
 }
 
 func j(s []string) string {

--- a/mock.go
+++ b/mock.go
@@ -165,7 +165,8 @@ func (mo mockMultiOp) Preflight() error {
 
 func (ks *mockKeySpace) NewTable(name string, entity interface{}, fieldSource map[string]interface{}, keys Keys) Table {
 	mt := &MockTable{
-		name:        name,
+		ksName:      ks.Name(),
+		tableName:   name,
 		entity:      entity,
 		keys:        keys,
 		fieldSource: fieldSource,
@@ -194,7 +195,8 @@ type MockTable struct {
 
 	// rows is mapping from row key to column group key to column map
 	mtx         *sync.RWMutex
-	name        string
+	ksName      string
+	tableName   string
 	rows        map[rowKey]*btree.BTree
 	entity      interface{}
 	fieldSource map[string]interface{}
@@ -339,7 +341,7 @@ func (t *MockTable) Name() string {
 	if len(t.options.TableName) > 0 {
 		return t.options.TableName
 	}
-	return t.name
+	return t.tableName
 }
 
 func (t *MockTable) getOrCreateRow(rowKey key) *btree.BTree {
@@ -428,7 +430,8 @@ func (t *MockTable) Recreate() error {
 
 func (t *MockTable) WithOptions(o Options) Table {
 	return &MockTable{
-		name:        t.name,
+		ksName:      t.ksName,
+		tableName:   t.tableName,
 		rows:        t.rows,
 		entity:      t.entity,
 		keys:        t.keys,
@@ -607,7 +610,7 @@ func (q *MockFilter) Read(out interface{}) Op {
 			fieldNames = q.table.fields
 		}
 
-		stmt := SelectStatement{keyspace: "mock", table: "mock", fields: fieldNames}
+		stmt := SelectStatement{keyspace: q.table.ksName, table: q.table.Name(), fields: fieldNames}
 		iter := newMockIterator(result, stmt.fields)
 		_, err = newScanner(stmt, out).ScanIter(iter)
 		return err

--- a/mock.go
+++ b/mock.go
@@ -73,7 +73,7 @@ func (m mockOp) RunAtomicallyWithContext(ctx context.Context) error {
 }
 
 func (m mockOp) GenerateStatement() Statement {
-	return noOpStatement
+	return noOpStatement{}
 }
 
 func (m mockOp) QueryExecutor() QueryExecutor {
@@ -115,7 +115,7 @@ func (mo mockMultiOp) RunAtomicallyWithContext(ctx context.Context) error {
 }
 
 func (mo mockMultiOp) GenerateStatement() Statement {
-	return noOpStatement
+	return noOpStatement{}
 }
 
 func (mo mockMultiOp) QueryExecutor() QueryExecutor {
@@ -411,7 +411,7 @@ func (t *MockTable) Create() error {
 }
 
 func (t *MockTable) CreateStatement() (Statement, error) {
-	return noOpStatement, nil
+	return noOpStatement{}, nil
 }
 
 func (t *MockTable) CreateIfNotExist() error {
@@ -419,7 +419,7 @@ func (t *MockTable) CreateIfNotExist() error {
 }
 
 func (t *MockTable) CreateIfNotExistStatement() (Statement, error) {
-	return noOpStatement, nil
+	return noOpStatement{}, nil
 }
 
 func (t *MockTable) Recreate() error {

--- a/mock.go
+++ b/mock.go
@@ -607,8 +607,8 @@ func (q *MockFilter) Read(out interface{}) Op {
 			fieldNames = q.table.fields
 		}
 
-		stmt := newSelectStatement("", []interface{}{}, fieldNames)
-		iter := newMockIterator(result, stmt.FieldNames())
+		stmt := SelectStatement{keyspace: "mock", table: "mock", fields: fieldNames}
+		iter := newMockIterator(result, stmt.fields)
 		_, err = newScanner(stmt, out).ScanIter(iter)
 		return err
 	})

--- a/multiop.go
+++ b/multiop.go
@@ -55,7 +55,7 @@ func (mo multiOp) RunAtomicallyWithContext(ctx context.Context) error {
 }
 
 func (mo multiOp) GenerateStatement() Statement {
-	return noOpStatement
+	return noOpStatement{}
 }
 
 func (mo multiOp) QueryExecutor() QueryExecutor {

--- a/op.go
+++ b/op.go
@@ -109,7 +109,7 @@ func (o *singleOp) GenerateStatement() Statement {
 	case readOpType, singleReadOpType:
 		return o.generateRead(o.options)
 	}
-	return noOpStatement
+	return noOpStatement{}
 }
 
 func (o *singleOp) QueryExecutor() QueryExecutor {

--- a/op.go
+++ b/op.go
@@ -1,11 +1,7 @@
 package gocassa
 
 import (
-	"bytes"
-	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 
 	"context"
 )
@@ -57,31 +53,21 @@ func newWriteOp(qe QueryExecutor, f filter, opType uint8, m map[string]interface
 		m:      m}
 }
 
-func (w *singleOp) read() error {
-	stmt := w.generateRead(w.options).(statement)
-	scanner := newScanner(stmt, w.result)
-	return w.qe.QueryWithOptions(w.options, stmt, scanner)
-}
-
-func (w *singleOp) readOne() error {
-	stmt := w.generateRead(w.options).(statement)
-	scanner := newScanner(stmt, w.result)
-	return w.qe.QueryWithOptions(w.options, stmt, scanner)
-}
-
-func (w *singleOp) write() error {
-	stmt := w.generateWrite(w.options)
-	return w.qe.ExecuteWithOptions(w.options, stmt)
-}
-
 func (o *singleOp) Run() error {
 	switch o.opType {
-	case updateOpType, insertOpType, deleteOpType:
-		return o.write()
-	case readOpType:
-		return o.read()
-	case singleReadOpType:
-		return o.readOne()
+	case readOpType, singleReadOpType:
+		stmt := o.generateSelect(o.options)
+		scanner := newScanner(stmt, o.result)
+		return o.qe.QueryWithOptions(o.options, stmt, scanner)
+	case insertOpType:
+		stmt := o.generateInsert(o.options)
+		return o.qe.ExecuteWithOptions(o.options, stmt)
+	case updateOpType:
+		stmt := o.generateUpdate(o.options)
+		return o.qe.ExecuteWithOptions(o.options, stmt)
+	case deleteOpType:
+		stmt := o.generateDelete(o.options)
+		return o.qe.ExecuteWithOptions(o.options, stmt)
 	}
 	return nil
 }
@@ -104,10 +90,14 @@ func (o *singleOp) RunAtomicallyWithContext(ctx context.Context) error {
 
 func (o *singleOp) GenerateStatement() Statement {
 	switch o.opType {
-	case updateOpType, insertOpType, deleteOpType:
-		return o.generateWrite(o.options)
 	case readOpType, singleReadOpType:
-		return o.generateRead(o.options)
+		return o.generateSelect(o.options)
+	case insertOpType:
+		return o.generateInsert(o.options)
+	case updateOpType:
+		return o.generateUpdate(o.options)
+	case deleteOpType:
+		return o.generateDelete(o.options)
 	}
 	return noOpStatement{}
 }
@@ -116,143 +106,46 @@ func (o *singleOp) QueryExecutor() QueryExecutor {
 	return o.qe
 }
 
-func (o *singleOp) generateWrite(opt Options) Statement {
-	var str string
-	var vals []interface{}
-	switch o.opType {
-	case updateOpType:
-		stmt, uvals := updateStatement(o.f.t.keySpace.name, o.f.t.Name(), o.m, o.f.t.options.Merge(opt))
-		whereStmt, whereVals := generateWhere(o.f.rs)
-		str = stmt + whereStmt
-		vals = append(uvals, whereVals...)
-	case deleteOpType:
-		str, vals = generateWhere(o.f.rs)
-		str = fmt.Sprintf("DELETE FROM %s.%s%s", o.f.t.keySpace.name, o.f.t.Name(), str)
-	case insertOpType:
-		str, vals = insertStatement(o.f.t.keySpace.name, o.f.t.Name(), o.m, o.f.t.options.Merge(opt))
-	}
-	if o.f.t.keySpace.debugMode {
-		fmt.Println(str, vals)
-	}
-	return newStatement(str, vals)
-}
-
-func (o *singleOp) generateRead(opt Options) Statement {
-	w, wv := generateWhere(o.f.rs)
+func (o *singleOp) generateSelect(opt Options) SelectStatement {
 	mopt := o.f.t.options.Merge(opt)
-	fl := o.f.t.generateFieldList(mopt.Select)
-	ord, ov := o.generateOrderBy(mopt)
-	lim, lv := o.generateLimit(mopt)
-	stmt := fmt.Sprintf("SELECT %s FROM %s.%s", strings.Join(fl, ","), o.f.t.keySpace.name, o.f.t.Name())
-	vals := []interface{}{}
-	buf := new(bytes.Buffer)
-	buf.WriteString(stmt)
-	if w != "" {
-		buf.WriteRune(' ')
-		buf.WriteString(w)
-		vals = append(vals, wv...)
+	return SelectStatement{
+		keyspace:       o.f.t.keySpace.name,
+		table:          o.f.t.Name(),
+		fields:         o.f.t.generateFieldList(mopt.Select),
+		where:          o.f.rs,
+		order:          mopt.ClusteringOrder,
+		limit:          mopt.Limit,
+		allowFiltering: mopt.AllowFiltering,
 	}
-	if ord != "" {
-		buf.WriteRune(' ')
-		buf.WriteString(ord)
-		vals = append(vals, ov...)
-	}
-	if lim != "" {
-		buf.WriteRune(' ')
-		buf.WriteString(lim)
-		vals = append(vals, lv...)
-	}
-	if opt.AllowFiltering {
-		buf.WriteString(" ")
-		buf.WriteString("ALLOW FILTERING")
-	}
-	if o.f.t.keySpace.debugMode {
-		fmt.Println(buf.String(), vals)
-	}
-	return newSelectStatement(buf.String(), vals, fl)
 }
 
-func (o *singleOp) generateOrderBy(opt Options) (string, []interface{}) {
-	if len(opt.ClusteringOrder) < 1 {
-		return "", []interface{}{}
+func (o *singleOp) generateInsert(opt Options) InsertStatement {
+	mopt := o.f.t.options.Merge(opt)
+	return InsertStatement{
+		keyspace: o.f.t.keySpace.name,
+		table:    o.f.t.Name(),
+		fieldMap: o.m,
+		ttl:      mopt.TTL,
 	}
-
-	buf := new(bytes.Buffer)
-	buf.WriteString("ORDER BY ")
-	for i, co := range opt.ClusteringOrder {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-
-		buf.WriteString(co.Column)
-		buf.WriteString(" ")
-		buf.WriteString(co.Direction.String())
-	}
-	return buf.String(), []interface{}{}
 }
 
-func (o *singleOp) generateLimit(opt Options) (string, []interface{}) {
-	if opt.Limit < 1 {
-		return "", []interface{}{}
+func (o *singleOp) generateUpdate(opt Options) UpdateStatement {
+	mopt := o.f.t.options.Merge(opt)
+	return UpdateStatement{
+		keyspace: o.f.t.keySpace.name,
+		table:    o.f.t.Name(),
+		fieldMap: o.m,
+		where:    o.f.rs,
+		ttl:      mopt.TTL,
 	}
-	return "LIMIT ?", []interface{}{opt.Limit}
 }
 
-func generateWhere(rs []Relation) (string, []interface{}) {
-	var (
-		vals []interface{}
-		buf  = new(bytes.Buffer)
-	)
-
-	if len(rs) > 0 {
-		buf.WriteString(" WHERE ")
-		for i, r := range rs {
-			if i > 0 {
-				buf.WriteString(" AND ")
-			}
-			s, v := r.cql()
-			buf.WriteString(s)
-			if r.Comparator() == CmpIn {
-				vals = append(vals, v)
-				continue
-			}
-			vals = append(vals, v...)
-		}
+func (o *singleOp) generateDelete(opt Options) DeleteStatement {
+	return DeleteStatement{
+		keyspace: o.f.t.keySpace.name,
+		table:    o.f.t.Name(),
+		where:    o.f.rs,
 	}
-	return buf.String(), vals
-}
-
-// UPDATE keyspace.Movies SET col1 = val1, col2 = val2
-func updateStatement(kn, cfName string, fields map[string]interface{}, opts Options) (string, []interface{}) {
-	buf := new(bytes.Buffer)
-	buf.WriteString(fmt.Sprintf("UPDATE %s.%s ", kn, cfName))
-
-	ret := []interface{}{}
-
-	// Apply options
-	if opts.TTL != 0 {
-		buf.WriteString("USING TTL ? ")
-		ret = append(ret, strconv.FormatFloat(opts.TTL.Seconds(), 'f', 0, 64))
-	}
-
-	buf.WriteString("SET ")
-	i := 0
-	for _, k := range sortedKeys(fields) {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		if mod, ok := fields[k].(Modifier); ok {
-			stmt, vals := mod.cql(k)
-			buf.WriteString(stmt)
-			ret = append(ret, vals...)
-		} else {
-			buf.WriteString(k + " = ?")
-			ret = append(ret, fields[k])
-		}
-		i++
-	}
-
-	return buf.String(), ret
 }
 
 func sortedKeys(m map[string]interface{}) []string {

--- a/options.go
+++ b/options.go
@@ -32,6 +32,10 @@ type ClusteringOrderColumn struct {
 	Column    string
 }
 
+func (c ClusteringOrderColumn) Field() string {
+	return c.Column
+}
+
 // Options can contain table or statement specific options.
 // The reason for this is because statement specific (TTL, Limit) options make sense as table level options
 // (eg. have default TTL for every Update without specifying it all the time)

--- a/relation.go
+++ b/relation.go
@@ -26,6 +26,9 @@ const (
 type Relation struct {
 	cmp   Comparator
 	field string
+	// terms represents the list of terms on the right hand side to match
+	// against. It is expected that all comparators except the CmpIn have
+	// exactly one term.
 	terms []interface{}
 }
 

--- a/relation.go
+++ b/relation.go
@@ -3,7 +3,6 @@ package gocassa
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 )
 
@@ -46,26 +45,6 @@ func (r Relation) Comparator() Comparator {
 // will always have at least one term present
 func (r Relation) Terms() []interface{} {
 	return r.terms
-}
-
-func (r Relation) cql() (string, []interface{}) {
-	ret := ""
-	field := strings.ToLower(r.Field())
-	switch r.Comparator() {
-	case CmpEquality:
-		ret = field + " = ?"
-	case CmpIn:
-		return field + " IN ?", r.Terms()
-	case CmpGreaterThan:
-		ret = field + " > ?"
-	case CmpGreaterThanOrEquals:
-		ret = field + " >= ?"
-	case CmpLesserThan:
-		ret = field + " < ?"
-	case CmpLesserThanOrEquals:
-		ret = field + " <= ?"
-	}
-	return ret, r.Terms()
 }
 
 func anyEquals(value interface{}, terms []interface{}) bool {

--- a/scanner.go
+++ b/scanner.go
@@ -14,13 +14,13 @@ import (
 // iterator and is responsible for unmarshalling into the struct or slice
 // of structs provided.
 type scanner struct {
-	stmt statement
+	stmt SelectStatement
 
 	result      interface{}
 	rowsScanned int
 }
 
-func newScanner(stmt statement, result interface{}) *scanner {
+func newScanner(stmt SelectStatement, result interface{}) *scanner {
 	return &scanner{
 		stmt:        stmt,
 		result:      result,
@@ -130,8 +130,8 @@ func (s *scanner) iterSingle(iter Scannable) (int, error) {
 	return 1, nil
 }
 
-// structFields matches the statement field names selected to names of fields
-// within the target struct type
+// structFields matches the SelectStatement field names selected to names of
+// fields within the target struct type
 func (s *scanner) structFields(structType reflect.Type) ([]*r.Field, error) {
 	fmPtr := reflect.New(structType).Interface()
 	m, err := r.StructFieldMap(fmPtr, true)
@@ -139,8 +139,8 @@ func (s *scanner) structFields(structType reflect.Type) ([]*r.Field, error) {
 		return nil, fmt.Errorf("could not decode struct of type %T: %v", fmPtr, err)
 	}
 
-	structFields := make([]*r.Field, len(s.stmt.fieldNames))
-	for i, fieldName := range s.stmt.fieldNames {
+	structFields := make([]*r.Field, len(s.stmt.fields))
+	for i, fieldName := range s.stmt.fields {
 		field, ok := m[strings.ToLower(fieldName)]
 		if !ok { // the field doesn't have a destination
 			structFields[i] = nil

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -19,8 +19,9 @@ func TestScanIterSlice(t *testing.T) {
 		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
 	}
 
-	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "created"})
-	iter := newMockIterator(results, stmt.FieldNames())
+	fieldNames := []string{"id", "name", "created"}
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	expected := []Account{
 		{ID: "acc_abcd1", Name: "John"},
@@ -123,8 +124,9 @@ func TestScanIterStruct(t *testing.T) {
 		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
 	}
 
-	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "created"})
-	iter := newMockIterator(results, stmt.FieldNames())
+	fieldNames := []string{"id", "name", "created"}
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	expected := []Account{
 		{ID: "acc_abcd1", Name: "John"},
@@ -180,13 +182,13 @@ func TestScanIterStruct(t *testing.T) {
 
 	// Test for row not found
 	var f1 *Account
-	noResultsIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
+	noResultsIter := newMockIterator([]map[string]interface{}{}, stmt.fields)
 	rowsRead, err = newScanner(stmt, &f1).ScanIter(noResultsIter)
 	assert.EqualError(t, err, ":0: No rows returned")
 
 	// Test for a non-rows-not-found error
 	var g1 *Account
-	errorerIter := newMockIterator([]map[string]interface{}{}, stmt.FieldNames())
+	errorerIter := newMockIterator([]map[string]interface{}{}, stmt.fields)
 	errorScanner := newScanner(stmt, &g1)
 	expectedErr := fmt.Errorf("Something went baaaad")
 	errorerIter.err = expectedErr
@@ -201,8 +203,9 @@ func TestScanIterComposite(t *testing.T) {
 		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
 	}
 
-	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "metadata", "tags"})
-	iter := newMockIterator(results, stmt.FieldNames())
+	fieldNames := []string{"id", "name", "metadata", "tags"}
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	// Test decoding into a sturct with maps and slices
 	type metadataType map[string]string
@@ -232,8 +235,9 @@ func TestScanIterEmbedded(t *testing.T) {
 		{"id": "acc_abcd2", "name": "Jane", "created": "2018-05-02 20:00:00+0000"},
 	}
 
-	stmt := newSelectStatement("", []interface{}{}, []string{"id", "name", "created"})
-	iter := newMockIterator(results, stmt.FieldNames())
+	fieldNames := []string{"id", "name", "created"}
+	stmt := SelectStatement{keyspace: "test", table: "bench", fields: fieldNames}
+	iter := newMockIterator(results, stmt.fields)
 
 	type embeddedStruct struct {
 		*Account

--- a/statement.go
+++ b/statement.go
@@ -20,17 +20,18 @@ type SelectStatement struct {
 
 // Query provides the CQL query string for an SELECT query
 func (s SelectStatement) Query() string {
-	query, _ := s.queryAndValues()
+	query, _ := s.QueryAndValues()
 	return query
 }
 
 // Values provide the binding values for an SELECT query
 func (s SelectStatement) Values() []interface{} {
-	_, values := s.queryAndValues()
+	_, values := s.QueryAndValues()
 	return values
 }
 
-func (s SelectStatement) queryAndValues() (string, []interface{}) {
+// QueryAndValues returns the CQL query and any bind values
+func (s SelectStatement) QueryAndValues() (string, []interface{}) {
 	values := make([]interface{}, 0)
 	query := []string{
 		"SELECT",
@@ -72,17 +73,18 @@ type InsertStatement struct {
 
 // Query provides the CQL query string for an INSERT INTO query
 func (s InsertStatement) Query() string {
-	query, _ := s.queryAndValues()
+	query, _ := s.QueryAndValues()
 	return query
 }
 
 // Values provide the binding values for an INSERT INTO query
 func (s InsertStatement) Values() []interface{} {
-	_, values := s.queryAndValues()
+	_, values := s.QueryAndValues()
 	return values
 }
 
-func (s InsertStatement) queryAndValues() (string, []interface{}) {
+// QueryAndValues returns the CQL query and any bind values
+func (s InsertStatement) QueryAndValues() (string, []interface{}) {
 	query := []string{"INSERT INTO", fmt.Sprintf("%s.%s", s.keyspace, s.table)}
 
 	fieldNames := make([]string, 0, len(s.fieldMap))
@@ -118,17 +120,18 @@ type UpdateStatement struct {
 
 // Query provides the CQL query string for an UPDATE query
 func (s UpdateStatement) Query() string {
-	query, _ := s.queryAndValues()
+	query, _ := s.QueryAndValues()
 	return query
 }
 
 // Values provide the binding values for an UPDATE query
 func (s UpdateStatement) Values() []interface{} {
-	_, values := s.queryAndValues()
+	_, values := s.QueryAndValues()
 	return values
 }
 
-func (s UpdateStatement) queryAndValues() (string, []interface{}) {
+// QueryAndValues returns the CQL query and any bind values
+func (s UpdateStatement) QueryAndValues() (string, []interface{}) {
 	values := make([]interface{}, 0)
 	query := []string{"UPDATE", fmt.Sprintf("%s.%s", s.keyspace, s.table)}
 
@@ -160,17 +163,18 @@ type DeleteStatement struct {
 
 // Query provides the CQL query string for a DELETE query
 func (s DeleteStatement) Query() string {
-	query, _ := s.queryAndValues()
+	query, _ := s.QueryAndValues()
 	return query
 }
 
 // Values provide the binding values for a DELETE query
 func (s DeleteStatement) Values() []interface{} {
-	_, values := s.queryAndValues()
+	_, values := s.QueryAndValues()
 	return values
 }
 
-func (s DeleteStatement) queryAndValues() (string, []interface{}) {
+// QueryAndValues returns the CQL query and any bind values
+func (s DeleteStatement) QueryAndValues() (string, []interface{}) {
 	whereCQL, whereValues := generateWhereCQL(s.where)
 	query := fmt.Sprintf("DELETE FROM %s.%s", s.keyspace, s.table)
 	if whereCQL != "" {

--- a/statement.go
+++ b/statement.go
@@ -1,13 +1,13 @@
 package gocassa
 
+import "time"
+
 type statement struct {
 	fieldNames []string
 
 	values []interface{}
 	query  string
 }
-
-var noOpStatement = newStatement("", []interface{}{})
 
 // FieldNames contains the column names which will be selected
 // This will only be populated for SELECT queries
@@ -41,3 +41,52 @@ func newSelectStatement(query string, values []interface{}, fieldNames []string)
 		fieldNames: fieldNames,
 	}
 }
+
+// SelectStatement represents a read (SELECT) query for some data in C*
+// It satisfies the Statement interface
+type SelectStatement struct {
+	keyspace       string                  // name of the keyspace
+	table          string                  // name of the table
+	fields         []string                // list of fields we want to select
+	where          []Relation              // where filter clauses
+	order          []ClusteringOrderColumn // order by clauses
+	limit          int                     // limit count, 0 means no limit
+	allowFiltering bool                    // whether we should allow filtering
+}
+
+// InsertStatement represents an INSERT query to write some data in C*
+// It satisfies the Statement interface
+type InsertStatement struct {
+	keyspace string        // name of the keyspace
+	table    string        // name of the table
+	fields   []string      // fields to be inserted
+	values   []string      // values to be inserted
+	ttl      time.Duration // ttl of the row
+}
+
+// UpdateStatement represents an UPDATE query to update some data in C*
+// It satisfies the Statement interface
+type UpdateStatement struct {
+	keyspace string        // name of the keyspace
+	table    string        // name of the table
+	fields   []string      // fields to be updated
+	values   []string      // values to be updated
+	where    []Relation    // where filter clauses
+	ttl      time.Duration // ttl of the row
+}
+
+// DeleteStatement represents a DELETE query to delete some data in C*
+// It satisfies the Statement interface
+type DeleteStatement struct {
+	keyspace string     // name of the keyspace
+	table    string     // name of the table
+	where    []Relation // where filter clauses
+}
+
+// noOpStatement represents a statement that doesn't perform any specific
+// query. It's used internally for testing, satisfies the Statement interface
+type noOpStatement struct{}
+
+func (_ noOpStatement) Query() string { return "" }
+
+func (_ noOpStatement) Values() []interface{} { return []interface{}{} }

--- a/statement.go
+++ b/statement.go
@@ -6,46 +6,6 @@ import (
 	"time"
 )
 
-type statement struct {
-	fieldNames []string
-
-	values []interface{}
-	query  string
-}
-
-// FieldNames contains the column names which will be selected
-// This will only be populated for SELECT queries
-func (s statement) FieldNames() []string {
-	return s.fieldNames
-}
-
-// Values encapsulates binding values to be set within the CQL
-// query string as binding parameters. If there are no binding
-// parameters in the query, this will be the empty slice
-func (s statement) Values() []interface{} {
-	return s.values
-}
-
-// Query returns the CQL query for this statement
-func (s statement) Query() string {
-	return s.query
-}
-
-func newStatement(query string, values []interface{}) statement {
-	return statement{
-		query:  query,
-		values: values,
-	}
-}
-
-func newSelectStatement(query string, values []interface{}, fieldNames []string) statement {
-	return statement{
-		query:      query,
-		values:     values,
-		fieldNames: fieldNames,
-	}
-}
-
 // SelectStatement represents a read (SELECT) query for some data in C*
 // It satisfies the Statement interface
 type SelectStatement struct {
@@ -218,6 +178,16 @@ func (s DeleteStatement) queryAndValues() (string, []interface{}) {
 	}
 	return query, whereValues
 }
+
+// cqlStatement represents a statement that executes raw CQL
+type cqlStatement struct {
+	query  string
+	values []interface{}
+}
+
+func (s cqlStatement) Query() string { return s.query }
+
+func (s cqlStatement) Values() []interface{} { return s.values }
 
 // noOpStatement represents a statement that doesn't perform any specific
 // query. It's used internally for testing, satisfies the Statement interface

--- a/statement_test.go
+++ b/statement_test.go
@@ -45,6 +45,21 @@ func TestStatement(t *testing.T) {
 	}
 }
 
+func TestInsertStatement(t *testing.T) {
+	stmt := InsertStatement{keyspace: "ks1", table: "tbl1"}
+	stmt.fieldMap = map[string]interface{}{"a": "b"}
+	assert.Equal(t, "INSERT INTO ks1.tbl1 (a) VALUES (?)", stmt.Query())
+	assert.Equal(t, []interface{}{"b"}, stmt.Values())
+
+	stmt.fieldMap = map[string]interface{}{"a": "b", "c": "d"}
+	assert.Equal(t, "INSERT INTO ks1.tbl1 (a, c) VALUES (?, ?)", stmt.Query())
+	assert.Equal(t, []interface{}{"b", "d"}, stmt.Values())
+
+	stmt.ttl = 1 * time.Hour
+	assert.Equal(t, "INSERT INTO ks1.tbl1 (a, c) VALUES (?, ?) USING TTL ?", stmt.Query())
+	assert.Equal(t, []interface{}{"b", "d", 3600}, stmt.Values())
+}
+
 func TestUpdateStatement(t *testing.T) {
 	stmt := UpdateStatement{keyspace: "ks1", table: "tbl1"}
 	stmt.fieldMap = map[string]interface{}{"a": "b"}

--- a/statement_test.go
+++ b/statement_test.go
@@ -2,6 +2,8 @@ package gocassa
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStatement(t *testing.T) {
@@ -40,4 +42,71 @@ func TestStatement(t *testing.T) {
 	if len(stmtSelect.Values()) != 1 {
 		t.Fatalf("expected 1 value, got %d values", len(stmtSelect.FieldNames()))
 	}
+}
+
+func TestDeleteStatement(t *testing.T) {
+	stmt := DeleteStatement{keyspace: "ks1", table: "tbl1"}
+	assert.Equal(t, "DELETE FROM ks1.tbl1", stmt.Query())
+
+	stmt.where = []Relation{
+		Eq("foo", "bar"),
+	}
+	assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE foo = ?", stmt.Query())
+	assert.Equal(t, []interface{}{"bar"}, stmt.Values())
+
+	stmt.where = []Relation{
+		Eq("foo", "bar"),
+		In("baz", "a", "b", "c"),
+	}
+	assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE foo = ? AND baz IN ?", stmt.Query())
+	assert.Equal(t, []interface{}{"bar", []interface{}{"a", "b", "c"}}, stmt.Values())
+}
+
+func TestGenerateWhereCQL(t *testing.T) {
+	stmt, values := generateWhereCQL([]Relation{
+		Eq("foo", "bar"),
+	})
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, []interface{}{"bar"}, values)
+
+	stmt, values = generateWhereCQL([]Relation{
+		Eq("foo", "bar"),
+		In("baz", "a", "b", "c"),
+	})
+	assert.Equal(t, "foo = ? AND baz IN ?", stmt)
+	assert.Equal(t, []interface{}{"bar", []interface{}{"a", "b", "c"}}, values)
+}
+
+func TestGenerateRelationCQL(t *testing.T) {
+	stmt, value := generateRelationCQL(Eq("foo", "bar"))
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, "bar", value)
+
+	stmt, value = generateRelationCQL(Eq("FoO", "BAR"))
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, "BAR", value)
+
+	stmt, value = generateRelationCQL(In("foo", "a", "b", "c"))
+	assert.Equal(t, "foo IN ?", stmt)
+	assert.Equal(t, []interface{}{"a", "b", "c"}, value)
+
+	stmt, value = generateRelationCQL(GT("foo", 1))
+	assert.Equal(t, "foo > ?", stmt)
+	assert.Equal(t, 1, value)
+
+	stmt, value = generateRelationCQL(GTE("foo", 1))
+	assert.Equal(t, "foo >= ?", stmt)
+	assert.Equal(t, 1, value)
+
+	stmt, value = generateRelationCQL(LT("foo", 1))
+	assert.Equal(t, "foo < ?", stmt)
+	assert.Equal(t, 1, value)
+
+	stmt, value = generateRelationCQL(LTE("foo", 1))
+	assert.Equal(t, "foo <= ?", stmt)
+	assert.Equal(t, 1, value)
+
+	assert.PanicsWithValue(t, "unknown comparator -1", func() {
+		stmt, value = generateRelationCQL(Relation{cmp: -1})
+	})
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -7,44 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStatement(t *testing.T) {
-	query1 := "DROP KEYSPACE IF EXISTS fakekeyspace"
-	stmtPlain := newStatement(query1, []interface{}{})
-	if stmtPlain.Query() != query1 {
-		t.Fatalf("expected query '%s', got '%s'", query1, stmtPlain.Query())
-	}
-	if len(stmtPlain.FieldNames()) != 0 {
-		t.Fatalf("expected 0 fields, got %d fields", len(stmtPlain.FieldNames()))
-	}
-	if len(stmtPlain.Values()) != 0 {
-		t.Fatalf("expected 0 values, got %d values", len(stmtPlain.FieldNames()))
-	}
-
-	query2 := "DELETE FROM fakekeyspace.faketable WHERE id = ?"
-	stmtWithValues := newStatement(query2, []interface{}{"id_abcd1234"})
-	if stmtWithValues.Query() != query2 {
-		t.Fatalf("expected query '%s', got '%s'", query2, stmtWithValues.Query())
-	}
-	if len(stmtWithValues.FieldNames()) != 0 {
-		t.Fatalf("expected 0 fields, got %d fields", len(stmtWithValues.FieldNames()))
-	}
-	if len(stmtWithValues.Values()) != 1 {
-		t.Fatalf("expected 1 value, got %d values", len(stmtWithValues.FieldNames()))
-	}
-
-	query3 := "SELECT id, name, created FROM fakekeyspace.faketable WHERE id = ?"
-	stmtSelect := newSelectStatement(query3, []interface{}{"id_abcd1234"}, []string{"id", "name", "created"})
-	if stmtSelect.Query() != query3 {
-		t.Fatalf("expected query '%s', got '%s'", query3, stmtSelect.Query())
-	}
-	if len(stmtSelect.FieldNames()) != 3 {
-		t.Fatalf("expected 3 fields, got %d fields", len(stmtSelect.FieldNames()))
-	}
-	if len(stmtSelect.Values()) != 1 {
-		t.Fatalf("expected 1 value, got %d values", len(stmtSelect.FieldNames()))
-	}
-}
-
 func TestSelectStatement(t *testing.T) {
 	stmt := SelectStatement{keyspace: "ks1", table: "tbl1"}
 	stmt.fields = []string{"a", "b", "c"}


### PR DESCRIPTION
This PR refactors some of the internals of gocassa to centralise the CQL building logic around the Statement interface. Previously, it was contained within the mismash of the `Op` set of objects.

This PR makes a clean separation, the Op is responsible for building the commands up, it then hands over the reins to the Statement which is responsible for generating the query.

As a bonus, we now have great tests around generating a CQL query as that's much more self-contained. There were already suitable integration tests which i've leaned on to make sure we don't have other regressions. 

This PR is quite large so it's advised to go commit by commit 🙏 