### PR TITLE
Add Partition/Clustering Key and Constructors

### DIFF
--- a/op.go
+++ b/op.go
@@ -116,6 +116,7 @@ func (o *singleOp) generateSelect(opt Options) SelectStatement {
 		order:          mopt.ClusteringOrder,
 		limit:          mopt.Limit,
 		allowFiltering: mopt.AllowFiltering,
+		keys:           o.f.t.info.keys,
 	}
 }
 
@@ -126,6 +127,7 @@ func (o *singleOp) generateInsert(opt Options) InsertStatement {
 		table:    o.f.t.Name(),
 		fieldMap: o.m,
 		ttl:      mopt.TTL,
+		keys:     o.f.t.info.keys,
 	}
 }
 
@@ -137,6 +139,7 @@ func (o *singleOp) generateUpdate(opt Options) UpdateStatement {
 		fieldMap: o.m,
 		where:    o.f.rs,
 		ttl:      mopt.TTL,
+		keys:     o.f.t.info.keys,
 	}
 }
 
@@ -145,6 +148,7 @@ func (o *singleOp) generateDelete(opt Options) DeleteStatement {
 		keyspace: o.f.t.keySpace.name,
 		table:    o.f.t.Name(),
 		where:    o.f.rs,
+		keys:     o.f.t.info.keys,
 	}
 }
 

--- a/statement.go
+++ b/statement.go
@@ -16,6 +16,7 @@ type SelectStatement struct {
 	order          []ClusteringOrderColumn // order by clauses
 	limit          int                     // limit count, 0 means no limit
 	allowFiltering bool                    // whether we should allow filtering
+	keys           Keys                    // partition / clustering keys for table
 }
 
 // Query provides the CQL query string for an SELECT query
@@ -36,30 +37,74 @@ func (s SelectStatement) QueryAndValues() (string, []interface{}) {
 	query := []string{
 		"SELECT",
 		strings.Join(s.fields, ", "),
-		fmt.Sprintf("FROM %s.%s", s.keyspace, s.table),
+		fmt.Sprintf("FROM %s.%s", s.Keyspace(), s.Table()),
 	}
 
-	whereCQL, whereValues := generateWhereCQL(s.where)
+	whereCQL, whereValues := generateWhereCQL(s.Relations())
 	if whereCQL != "" {
 		query = append(query, "WHERE", whereCQL)
 		values = append(values, whereValues...)
 	}
 
-	orderByCQL := generateOrderByCQL(s.order)
+	orderByCQL := generateOrderByCQL(s.OrderBy())
 	if orderByCQL != "" {
 		query = append(query, "ORDER BY", orderByCQL)
 	}
 
-	if s.limit > 0 {
+	if s.Limit() > 0 {
 		query = append(query, "LIMIT ?")
 		values = append(values, s.limit)
 	}
 
-	if s.allowFiltering {
+	if s.AllowFiltering() {
 		query = append(query, "ALLOW FILTERING")
 	}
 
 	return strings.Join(query, " "), values
+}
+
+// Keyspace returns the name of the Keyspace for the statement
+func (s SelectStatement) Keyspace() string {
+	return s.keyspace
+}
+
+// Table returns the name of the table for this statement
+func (s SelectStatement) Table() string {
+	return s.table
+}
+
+// Fields returns the list of fields to be selected
+func (s SelectStatement) Fields() []string {
+	return s.fields
+}
+
+// Relations provides the WHERE clause Relation items used to evaluate
+// this query
+func (s SelectStatement) Relations() []Relation {
+	return s.where
+}
+
+// OrderBy returns the ClusteringOrderColumn clauses used
+func (s SelectStatement) OrderBy() []ClusteringOrderColumn {
+	return s.order
+}
+
+// Limit returns the number of rows to be returned, a value of zero
+// means no limit
+func (s SelectStatement) Limit() int {
+	if s.limit < 1 {
+		return 0
+	}
+	return s.limit
+}
+
+func (s SelectStatement) AllowFiltering() bool {
+	return s.allowFiltering
+}
+
+// Keys provides the Partition / Clustering keys defined by the table recipe
+func (s SelectStatement) Keys() Keys {
+	return s.keys
 }
 
 // InsertStatement represents an INSERT query to write some data in C*
@@ -69,6 +114,7 @@ type InsertStatement struct {
 	table    string                 // name of the table
 	fieldMap map[string]interface{} // fields to be inserted
 	ttl      time.Duration          // ttl of the row
+	keys     Keys                   // partition / clustering keys for table
 }
 
 // Query provides the CQL query string for an INSERT INTO query
@@ -85,27 +131,58 @@ func (s InsertStatement) Values() []interface{} {
 
 // QueryAndValues returns the CQL query and any bind values
 func (s InsertStatement) QueryAndValues() (string, []interface{}) {
-	query := []string{"INSERT INTO", fmt.Sprintf("%s.%s", s.keyspace, s.table)}
+	query := []string{"INSERT INTO", fmt.Sprintf("%s.%s", s.Keyspace(), s.Table())}
 
-	fieldNames := make([]string, 0, len(s.fieldMap))
-	placeholders := make([]string, 0, len(s.fieldMap))
-	values := make([]interface{}, 0, len(s.fieldMap))
-	for _, field := range sortedKeys(s.fieldMap) {
+	fieldMap := s.FieldMap()
+	fieldNames := make([]string, 0, len(fieldMap))
+	placeholders := make([]string, 0, len(fieldMap))
+	values := make([]interface{}, 0, len(fieldMap))
+	for _, field := range sortedKeys(fieldMap) {
 		fieldNames = append(fieldNames, strings.ToLower(field))
 		placeholders = append(placeholders, "?")
-		values = append(values, s.fieldMap[field])
+		values = append(values, fieldMap[field])
 	}
 
 	query = append(query, "("+strings.Join(fieldNames, ", ")+")")
 	query = append(query, "VALUES ("+strings.Join(placeholders, ", ")+")")
 
 	// Determine if we need to set a TTL
-	if s.ttl > 0 {
+	if s.TTL() > time.Duration(0) {
 		query = append(query, "USING TTL ?")
-		values = append(values, int(s.ttl.Seconds()))
+		values = append(values, int(s.TTL().Seconds()))
 	}
 
 	return strings.Join(query, " "), values
+}
+
+// Keyspace returns the name of the Keyspace for the statement
+func (s InsertStatement) Keyspace() string {
+	return s.keyspace
+}
+
+// Table returns the name of the table for this statement
+func (s InsertStatement) Table() string {
+	return s.table
+}
+
+// FieldMap gives a map of all the fields to be inserted. In an INSERT
+// statement, none of these will be Modifier types
+func (s InsertStatement) FieldMap() map[string]interface{} {
+	return s.fieldMap
+}
+
+// TTL returns the Time-To-Live for this row statement. A duration of 0
+// means there is no TTL
+func (s InsertStatement) TTL() time.Duration {
+	if s.ttl < time.Duration(1) {
+		return time.Duration(0)
+	}
+	return s.ttl
+}
+
+// Keys provides the Partition / Clustering keys defined by the table recipe
+func (s InsertStatement) Keys() Keys {
+	return s.keys
 }
 
 // UpdateStatement represents an UPDATE query to update some data in C*
@@ -116,6 +193,7 @@ type UpdateStatement struct {
 	fieldMap map[string]interface{} // fields to be updated
 	where    []Relation             // where filter clauses
 	ttl      time.Duration          // ttl of the row
+	keys     Keys                   // partition / clustering keys for table
 }
 
 // Query provides the CQL query string for an UPDATE query
@@ -133,24 +211,60 @@ func (s UpdateStatement) Values() []interface{} {
 // QueryAndValues returns the CQL query and any bind values
 func (s UpdateStatement) QueryAndValues() (string, []interface{}) {
 	values := make([]interface{}, 0)
-	query := []string{"UPDATE", fmt.Sprintf("%s.%s", s.keyspace, s.table)}
+	query := []string{"UPDATE", fmt.Sprintf("%s.%s", s.Keyspace(), s.Table())}
 
 	// Determine if we need to set a TTL
-	if s.ttl > 0 {
+	if s.TTL() > 0 {
 		query = append(query, "USING TTL ?")
-		values = append(values, int(s.ttl.Seconds()))
+		values = append(values, int(s.TTL().Seconds()))
 	}
 
-	setCQL, setValues := generateUpdateSetCQL(s.fieldMap)
+	setCQL, setValues := generateUpdateSetCQL(s.FieldMap())
 	query = append(query, "SET", setCQL)
 	values = append(values, setValues...)
 
-	whereCQL, whereValues := generateWhereCQL(s.where)
+	whereCQL, whereValues := generateWhereCQL(s.Relations())
 	if whereCQL != "" {
 		query = append(query, "WHERE", whereCQL)
 		values = append(values, whereValues...)
 	}
 	return strings.Join(query, " "), values
+}
+
+// Keyspace returns the name of the Keyspace for the statement
+func (s UpdateStatement) Keyspace() string {
+	return s.keyspace
+}
+
+// Table returns the name of the table for this statement
+func (s UpdateStatement) Table() string {
+	return s.table
+}
+
+// FieldMap gives a map of all the fields to be inserted. In an UPDATE
+// statement, the values may be Modifier types
+func (s UpdateStatement) FieldMap() map[string]interface{} {
+	return s.fieldMap
+}
+
+// Relations provides the WHERE clause Relation items used to evaluate
+// this query
+func (s UpdateStatement) Relations() []Relation {
+	return s.where
+}
+
+// TTL returns the Time-To-Live for this row statement. A duration of 0
+// means there is no TTL
+func (s UpdateStatement) TTL() time.Duration {
+	if s.ttl < time.Duration(1) {
+		return time.Duration(0)
+	}
+	return s.ttl
+}
+
+// Keys provides the Partition / Clustering keys defined by the table recipe
+func (s UpdateStatement) Keys() Keys {
+	return s.keys
 }
 
 // DeleteStatement represents a DELETE query to delete some data in C*
@@ -159,6 +273,7 @@ type DeleteStatement struct {
 	keyspace string     // name of the keyspace
 	table    string     // name of the table
 	where    []Relation // where filter clauses
+	keys     Keys       // partition / clustering keys for table
 }
 
 // Query provides the CQL query string for a DELETE query
@@ -175,12 +290,33 @@ func (s DeleteStatement) Values() []interface{} {
 
 // QueryAndValues returns the CQL query and any bind values
 func (s DeleteStatement) QueryAndValues() (string, []interface{}) {
-	whereCQL, whereValues := generateWhereCQL(s.where)
-	query := fmt.Sprintf("DELETE FROM %s.%s", s.keyspace, s.table)
+	query := fmt.Sprintf("DELETE FROM %s.%s", s.Keyspace(), s.Table())
+	whereCQL, whereValues := generateWhereCQL(s.Relations())
 	if whereCQL != "" {
 		query += " WHERE " + whereCQL
 	}
 	return query, whereValues
+}
+
+// Keyspace returns the name of the Keyspace for the statement
+func (s DeleteStatement) Keyspace() string {
+	return s.keyspace
+}
+
+// Table returns the name of the table for this statement
+func (s DeleteStatement) Table() string {
+	return s.table
+}
+
+// Relations provides the WHERE clause Relation items used to evaluate
+// this query
+func (s DeleteStatement) Relations() []Relation {
+	return s.where
+}
+
+// Keys provides the Partition / Clustering keys defined by the table recipe
+func (s DeleteStatement) Keys() Keys {
+	return s.keys
 }
 
 // cqlStatement represents a statement that executes raw CQL

--- a/statement.go
+++ b/statement.go
@@ -19,6 +19,30 @@ type SelectStatement struct {
 	keys           Keys                    // partition / clustering keys for table
 }
 
+// NewSelectStatement adds the ability to craft a new SelectStatement
+// This function will error if the parameters passed in are invalid
+func NewSelectStatement(keyspace, table string, fields []string, rel []Relation, keys Keys) (SelectStatement, error) {
+	stmt := SelectStatement{}
+	if keyspace == "" || table == "" {
+		return stmt, fmt.Errorf("keyspace and table can't be empty")
+	}
+
+	if len(fields) < 1 {
+		return stmt, fmt.Errorf("fields must be a list of string fields to select")
+	}
+
+	if len(keys.PartitionKeys) == 0 {
+		return stmt, fmt.Errorf("partition key should be supplied")
+	}
+
+	stmt.keyspace = keyspace
+	stmt.table = table
+	stmt.fields = fields
+	stmt.where = rel
+	stmt.keys = keys
+	return stmt, nil
+}
+
 // Query provides the CQL query string for an SELECT query
 func (s SelectStatement) Query() string {
 	query, _ := s.QueryAndValues()
@@ -84,9 +108,21 @@ func (s SelectStatement) Relations() []Relation {
 	return s.where
 }
 
+// WithRelations sets the relations (WHERE conditions) for this statement
+func (s SelectStatement) WithRelations(rel []Relation) SelectStatement {
+	s.where = rel
+	return s
+}
+
 // OrderBy returns the ClusteringOrderColumn clauses used
 func (s SelectStatement) OrderBy() []ClusteringOrderColumn {
 	return s.order
+}
+
+// WithOrderBy allows the setting of the clustering order columns
+func (s SelectStatement) WithOrderBy(order []ClusteringOrderColumn) SelectStatement {
+	s.order = order
+	return s
 }
 
 // Limit returns the number of rows to be returned, a value of zero
@@ -98,8 +134,26 @@ func (s SelectStatement) Limit() int {
 	return s.limit
 }
 
+// WithLimit allows the setting of a limit. Using a value of zero or a negative
+// value removes the limit
+func (s SelectStatement) WithLimit(limit int) SelectStatement {
+	if limit < 1 {
+		limit = 0
+	}
+	s.limit = limit
+	return s
+}
+
+// AllowFiltering returns whether data filtering (ALLOW FILTERING) is enabled
 func (s SelectStatement) AllowFiltering() bool {
 	return s.allowFiltering
+}
+
+// WithAllowFiltering allows toggling of data filtering (including
+// ALLOW FILTERING in the CQL)
+func (s SelectStatement) WithAllowFiltering(enabled bool) SelectStatement {
+	s.allowFiltering = enabled
+	return s
 }
 
 // Keys provides the Partition / Clustering keys defined by the table recipe
@@ -115,6 +169,29 @@ type InsertStatement struct {
 	fieldMap map[string]interface{} // fields to be inserted
 	ttl      time.Duration          // ttl of the row
 	keys     Keys                   // partition / clustering keys for table
+}
+
+// NewInsertStatement adds the ability to craft a new InsertStatement
+// This function will error if the parameters passed in are invalid
+func NewInsertStatement(keyspace, table string, fieldMap map[string]interface{}, keys Keys) (InsertStatement, error) {
+	stmt := InsertStatement{}
+	if keyspace == "" || table == "" {
+		return stmt, fmt.Errorf("keyspace and table can't be empty")
+	}
+
+	if len(fieldMap) < 1 {
+		return stmt, fmt.Errorf("fieldMap must be a map fields to insert")
+	}
+
+	if len(keys.PartitionKeys) == 0 {
+		return stmt, fmt.Errorf("partition key should be supplied")
+	}
+
+	stmt.keyspace = keyspace
+	stmt.table = table
+	stmt.fieldMap = fieldMap
+	stmt.keys = keys
+	return stmt, nil
 }
 
 // Query provides the CQL query string for an INSERT INTO query
@@ -180,6 +257,16 @@ func (s InsertStatement) TTL() time.Duration {
 	return s.ttl
 }
 
+// WithTTL allows setting of the time-to-live for this insert statement.
+// A duration of 0 means there is no TTL
+func (s InsertStatement) WithTTL(ttl time.Duration) InsertStatement {
+	if ttl < time.Duration(1) {
+		ttl = time.Duration(0)
+	}
+	s.ttl = ttl
+	return s
+}
+
 // Keys provides the Partition / Clustering keys defined by the table recipe
 func (s InsertStatement) Keys() Keys {
 	return s.keys
@@ -194,6 +281,34 @@ type UpdateStatement struct {
 	where    []Relation             // where filter clauses
 	ttl      time.Duration          // ttl of the row
 	keys     Keys                   // partition / clustering keys for table
+}
+
+// NewUpdateStatement adds the ability to craft a new UpdateStatement
+// This function will error if the parameters passed in are invalid
+func NewUpdateStatement(keyspace, table string, fieldMap map[string]interface{}, rel []Relation, keys Keys) (UpdateStatement, error) {
+	stmt := UpdateStatement{}
+	if keyspace == "" || table == "" {
+		return stmt, fmt.Errorf("keyspace and table can't be empty")
+	}
+
+	if len(fieldMap) < 1 {
+		return stmt, fmt.Errorf("fieldMap must be a map fields to insert")
+	}
+
+	if len(rel) < 1 {
+		return stmt, fmt.Errorf("must supply at least one relation WHERE clause")
+	}
+
+	if len(keys.PartitionKeys) == 0 {
+		return stmt, fmt.Errorf("partition key should be supplied")
+	}
+
+	stmt.keyspace = keyspace
+	stmt.table = table
+	stmt.fieldMap = fieldMap
+	stmt.where = rel
+	stmt.keys = keys
+	return stmt, nil
 }
 
 // Query provides the CQL query string for an UPDATE query
@@ -262,6 +377,16 @@ func (s UpdateStatement) TTL() time.Duration {
 	return s.ttl
 }
 
+// WithTTL allows setting of the time-to-live for this insert statement.
+// A duration of 0 means there is no TTL
+func (s UpdateStatement) WithTTL(ttl time.Duration) UpdateStatement {
+	if ttl < time.Duration(1) {
+		ttl = time.Duration(0)
+	}
+	s.ttl = ttl
+	return s
+}
+
 // Keys provides the Partition / Clustering keys defined by the table recipe
 func (s UpdateStatement) Keys() Keys {
 	return s.keys
@@ -274,6 +399,29 @@ type DeleteStatement struct {
 	table    string     // name of the table
 	where    []Relation // where filter clauses
 	keys     Keys       // partition / clustering keys for table
+}
+
+// NewDeleteStatement adds the ability to craft a new DeleteStatement
+// This function will error if the parameters passed in are invalid
+func NewDeleteStatement(keyspace, table string, rel []Relation, keys Keys) (DeleteStatement, error) {
+	stmt := DeleteStatement{}
+	if keyspace == "" || table == "" {
+		return stmt, fmt.Errorf("keyspace and table can't be empty")
+	}
+
+	if len(rel) < 1 {
+		return stmt, fmt.Errorf("must supply at least one relation WHERE clause")
+	}
+
+	if len(keys.PartitionKeys) == 0 {
+		return stmt, fmt.Errorf("partition key should be supplied")
+	}
+
+	stmt.keyspace = keyspace
+	stmt.table = table
+	stmt.where = rel
+	stmt.keys = keys
+	return stmt, nil
 }
 
 // Query provides the CQL query string for a DELETE query

--- a/statement_test.go
+++ b/statement_test.go
@@ -8,89 +8,102 @@ import (
 )
 
 func TestSelectStatement(t *testing.T) {
-	stmt := SelectStatement{keyspace: "ks1", table: "tbl1"}
-	stmt.fields = []string{"a", "b", "c"}
+	fields := []string{"a", "b", "c"}
+	keys := Keys{PartitionKeys: []string{"a"}}
+	stmt, err := NewSelectStatement("ks1", "tbl1", fields, nil, keys)
+	assert.NoError(t, err)
 	assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1", stmt.Query())
 	assert.Equal(t, []interface{}{}, stmt.Values())
 
-	stmt.limit = 10
+	stmt = stmt.WithLimit(10)
 	assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 LIMIT ?", stmt.Query())
 	assert.Equal(t, []interface{}{10}, stmt.Values())
 
-	stmt.order = []ClusteringOrderColumn{
+	stmt = stmt.WithOrderBy([]ClusteringOrderColumn{
 		{Column: "a", Direction: ASC},
-	}
+	})
 	assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 ORDER BY a ASC LIMIT ?", stmt.Query())
 	assert.Equal(t, []interface{}{10}, stmt.Values())
 
-	stmt.where = []Relation{
+	stmt = stmt.WithRelations([]Relation{
 		Eq("foo", "bar"),
 		In("baz", "bing"),
-	}
+	})
 	assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 WHERE foo = ? AND baz IN ? ORDER BY a ASC LIMIT ?", stmt.Query())
 	assert.Equal(t, []interface{}{"bar", []interface{}{"bing"}, 10}, stmt.Values())
 
-	stmt.allowFiltering = true
+	stmt = stmt.WithAllowFiltering(true)
 	assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 WHERE foo = ? AND baz IN ? ORDER BY a ASC LIMIT ? ALLOW FILTERING", stmt.Query())
 	assert.Equal(t, []interface{}{"bar", []interface{}{"bing"}, 10}, stmt.Values())
 }
 
 func TestInsertStatement(t *testing.T) {
-	stmt := InsertStatement{keyspace: "ks1", table: "tbl1"}
-	stmt.fieldMap = map[string]interface{}{"a": "b"}
+	fieldMap := map[string]interface{}{"a": "b"}
+	keys := Keys{PartitionKeys: []string{"a"}}
+	stmt, err := NewInsertStatement("ks1", "tbl1", fieldMap, keys)
+	assert.NoError(t, err)
 	assert.Equal(t, "INSERT INTO ks1.tbl1 (a) VALUES (?)", stmt.Query())
 	assert.Equal(t, []interface{}{"b"}, stmt.Values())
 
-	stmt.fieldMap = map[string]interface{}{"a": "b", "c": "d"}
+	fieldMap = map[string]interface{}{"a": "b", "c": "d"}
+	stmt, err = NewInsertStatement("ks1", "tbl1", fieldMap, keys)
 	assert.Equal(t, "INSERT INTO ks1.tbl1 (a, c) VALUES (?, ?)", stmt.Query())
 	assert.Equal(t, []interface{}{"b", "d"}, stmt.Values())
 
-	stmt.ttl = 1 * time.Hour
+	stmt = stmt.WithTTL(1 * time.Hour)
 	assert.Equal(t, "INSERT INTO ks1.tbl1 (a, c) VALUES (?, ?) USING TTL ?", stmt.Query())
 	assert.Equal(t, []interface{}{"b", "d", 3600}, stmt.Values())
 }
 
 func TestUpdateStatement(t *testing.T) {
-	stmt := UpdateStatement{keyspace: "ks1", table: "tbl1"}
-	stmt.fieldMap = map[string]interface{}{"a": "b"}
-	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?", stmt.Query())
-	assert.Equal(t, []interface{}{"b"}, stmt.Values())
+	fieldMap := map[string]interface{}{"a": "b"}
+	relations := []Relation{Eq("foo", "bar")}
+	keys := Keys{PartitionKeys: []string{"foo"}}
+	stmt, err := NewUpdateStatement("ks1", "tbl1", fieldMap, relations, keys)
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ? WHERE foo = ?", stmt.Query())
+	assert.Equal(t, []interface{}{"b", "bar"}, stmt.Values())
 
-	stmt.fieldMap = map[string]interface{}{"a": "b", "c": ListAppend("d")}
-	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?, c = c + ?", stmt.Query())
-	assert.Equal(t, []interface{}{"b", []interface{}{"d"}}, stmt.Values())
+	fieldMap = map[string]interface{}{"a": "b", "c": ListAppend("d")}
+	stmt, err = NewUpdateStatement("ks1", "tbl1", fieldMap, relations, keys)
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?, c = c + ? WHERE foo = ?", stmt.Query())
+	assert.Equal(t, []interface{}{"b", []interface{}{"d"}, "bar"}, stmt.Values())
 
-	stmt.fieldMap = map[string]interface{}{"a": "b", "c": "d"}
-	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?, c = ?", stmt.Query())
-	assert.Equal(t, []interface{}{"b", "d"}, stmt.Values())
+	fieldMap = map[string]interface{}{"a": "b", "c": "d"}
+	stmt, err = NewUpdateStatement("ks1", "tbl1", fieldMap, relations, keys)
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?, c = ? WHERE foo = ?", stmt.Query())
+	assert.Equal(t, []interface{}{"b", "d", "bar"}, stmt.Values())
 
-	stmt.where = []Relation{
+	relations = []Relation{
 		Eq("foo", "bar"),
 		In("baz", "a", "b", "c"),
 	}
+	stmt, err = NewUpdateStatement("ks1", "tbl1", fieldMap, relations, keys)
+	assert.NoError(t, err)
 	assert.Equal(t, "UPDATE ks1.tbl1 SET a = ?, c = ? WHERE foo = ? AND baz IN ?", stmt.Query())
 	assert.Equal(t, []interface{}{"b", "d", "bar", []interface{}{"a", "b", "c"}}, stmt.Values())
 
-	stmt.ttl = 1 * time.Hour
+	stmt = stmt.WithTTL(1 * time.Hour)
 	assert.Equal(t, "UPDATE ks1.tbl1 USING TTL ? SET a = ?, c = ? WHERE foo = ? AND baz IN ?", stmt.Query())
 	assert.Equal(t, []interface{}{3600, "b", "d", "bar", []interface{}{"a", "b", "c"}}, stmt.Values())
 }
 
 func TestDeleteStatement(t *testing.T) {
-	stmt := DeleteStatement{keyspace: "ks1", table: "tbl1"}
-	assert.Equal(t, "DELETE FROM ks1.tbl1", stmt.Query())
-	assert.Equal(t, []interface{}{}, stmt.Values())
-
-	stmt.where = []Relation{
-		Eq("foo", "bar"),
-	}
+	keys := Keys{PartitionKeys: []string{"foo"}}
+	relations := []Relation{Eq("foo", "bar")}
+	stmt, err := NewDeleteStatement("ks1", "tbl1", relations, keys)
+	assert.NoError(t, err)
 	assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE foo = ?", stmt.Query())
 	assert.Equal(t, []interface{}{"bar"}, stmt.Values())
 
-	stmt.where = []Relation{
+	relations = []Relation{
 		Eq("foo", "bar"),
 		In("baz", "a", "b", "c"),
 	}
+	stmt, err = NewDeleteStatement("ks1", "tbl1", relations, keys)
+	assert.NoError(t, err)
 	assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE foo = ? AND baz IN ?", stmt.Query())
 	assert.Equal(t, []interface{}{"bar", []interface{}{"a", "b", "c"}}, stmt.Values())
 }


### PR DESCRIPTION
This PR adds constructors for our different Statement types (as well as primitive validation logic). It also includes plumbing of the Keys data type from the table info to provide information on the table partition/clustering keys.