### PR TITLE
Make slice decoding more performant 💨

### DIFF
--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -36,7 +36,7 @@ func StructToMap(val interface{}) (map[string]interface{}, bool) {
 	return mapVal, true
 }
 
-// StructFieldMap takes a struct and extracts the Field info into a map by
+// StructFieldMap takes a struct type and extracts the Field info into a map by
 // field name. The "cql" key in the struct field's tag value is the key
 // name. Examples:
 //
@@ -50,15 +50,12 @@ func StructToMap(val interface{}) (map[string]interface{}, bool) {
 //   Field int "myName"
 //
 // If lowercaseFields is set to true, field names are lowercased in the map
-func StructFieldMap(val interface{}, lowercaseFields bool) (map[string]Field, error) {
-	// indirect so function works with both structs and pointers to them
-	structVal := r.Indirect(r.ValueOf(val))
-	kind := structVal.Kind()
-	if kind != r.Struct {
-		return nil, fmt.Errorf("expected val to be a struct, got %T", val)
+func StructFieldMap(structType r.Type, lowercaseFields bool) (map[string]Field, error) {
+	if structType.Kind() != r.Struct {
+		return nil, fmt.Errorf("expected val to be a struct, got %v", structType)
 	}
 
-	structFields := cachedTypeFields(structVal.Type())
+	structFields := cachedTypeFields(structType)
 	mapVal := make(map[string]Field, len(structFields))
 	for _, info := range structFields {
 		name := info.name

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -4,7 +4,6 @@ package reflect
 import (
 	"fmt"
 	r "reflect"
-	"strings"
 )
 
 // StructToMap converts a struct to map. The object's default key string
@@ -54,30 +53,14 @@ func StructFieldMap(structType r.Type, lowercaseFields bool) (map[string]Field, 
 	if structType.Kind() != r.Struct {
 		return nil, fmt.Errorf("expected val to be a struct, got %v", structType)
 	}
-
-	structFields := cachedTypeFields(structType)
-	mapVal := make(map[string]Field, len(structFields))
-	for _, info := range structFields {
-		name := info.name
-		if lowercaseFields {
-			name = strings.ToLower(name)
-		}
-		mapVal[name] = info
-	}
-	return mapVal, nil
+	return cachedTypeFieldMap(structType, lowercaseFields), nil
 }
 
 // MapToStruct converts a map to a struct. It is the inverse of the StructToMap
 // function. For details see StructToMap.
 func MapToStruct(m map[string]interface{}, struc interface{}) error {
 	val := r.Indirect(r.ValueOf(struc))
-	structFields := cachedTypeFields(val.Type())
-
-	// Create fields map for faster lookup
-	fieldsMap := make(map[string]Field)
-	for _, field := range structFields {
-		fieldsMap[field.name] = field
-	}
+	fieldsMap := cachedTypeFieldMap(val.Type(), false)
 
 	for k, v := range m {
 		if info, ok := fieldsMap[k]; ok {

--- a/reflect/reflect_test.go
+++ b/reflect/reflect_test.go
@@ -138,7 +138,7 @@ func TestMapToStruct(t *testing.T) {
 }
 
 func TestStructFieldMap(t *testing.T) {
-	m, err := StructFieldMap(Tweet{}, false)
+	m, err := StructFieldMap(reflect.TypeOf(Tweet{}), false)
 	if err != nil {
 		t.Fatalf("expected field map to be created, err: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestStructFieldMap(t *testing.T) {
 	}
 
 	// Test lowercasing fields
-	m2, err := StructFieldMap(Tweet{}, true)
+	m2, err := StructFieldMap(reflect.TypeOf(Tweet{}), true)
 	if err != nil {
 		t.Fatalf("expected field map to be created, err: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestStructFieldMapEmbeddedStruct(t *testing.T) {
 		Embedder string
 	}
 
-	m, err := StructFieldMap(EmbeddedTweet{}, false)
+	m, err := StructFieldMap(reflect.TypeOf(EmbeddedTweet{}), false)
 	if err != nil {
 		t.Fatalf("expected field map to be created, err: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestStructFieldMapEmbeddedStruct(t *testing.T) {
 }
 
 func TestStructFieldMapNonStruct(t *testing.T) {
-	_, err := StructFieldMap(42, false)
+	_, err := StructFieldMap(reflect.TypeOf(42), false)
 	if err == nil {
 		t.Fatalf("expected StructFieldMap to have an error, got nil error")
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -85,7 +85,6 @@ func (s *scanner) iterSlice(iter Scannable) (int, error) {
 		setPtrs(structFields, ptrs, outVal)
 
 		sliceElem.Set(reflect.Append(sliceElem, wrapPtrValue(outVal, sliceElemType)))
-		ptrs = generatePtrs(structFields)
 		rowsScanned++
 	}
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -254,6 +254,27 @@ func TestScanIterEmbedded(t *testing.T) {
 	iter.Reset()
 }
 
+func TestFillInZeroedPtrs(t *testing.T) {
+	str := ""
+	strSlice := []string{}
+	strMap := map[string]string{}
+	strSliceNil := []string(nil)
+	strMapNil := map[string]string(nil)
+
+	// Test with already allocated
+	fillInZeroedPtrs([]interface{}{&str, &strSlice, &strMap})
+	assert.Equal(t, "", str)
+	assert.Equal(t, []string{}, strSlice)
+	assert.Equal(t, map[string]string{}, strMap)
+
+	// Test with nil allocated
+	assert.NotEqual(t, []string{}, strSliceNil)
+	assert.NotEqual(t, map[string]string{}, strMapNil)
+	fillInZeroedPtrs([]interface{}{&strSliceNil, &strMapNil})
+	assert.Equal(t, []string{}, strSliceNil)
+	assert.Equal(t, map[string]string{}, strMapNil)
+}
+
 func TestAllocateNilReference(t *testing.T) {
 	// Test non pointer, should do nothing
 	var a string


### PR DESCRIPTION
This PR makes a few tweaks to improve the performance of decoding into a slice
- When decoding a slice, a bug meant we were doing double allocations of slice values and then throwing the second set away (because they were never used)
- When we initialize/create a struct element, it comes pre-allocated with the zero values of elements. We can use those allocations rather than allocate ourselves again. This also saves some double allocations and gives as a bonus of not having to re-iterate and set the pointers (so instead of an intermediate variable to decode from struct element to intermediate variable to struct element), we just pass the direct struct element to be decoded into

This code is already [well covered with tests](https://github.com/monzo/gocassa/blob/master/scanner_test.go) so that gives confidence that nothing has changed behaviour wise.

Before:
```
pkg: github.com/monzo/gocassa
BenchmarkDecodeBlogSliceNoBody
BenchmarkDecodeBlogSliceNoBody-8       	   30699	     38875 ns/op	   26376 B/op	     388 allocs/op
BenchmarkDecodeBlogStruct
BenchmarkDecodeBlogStruct-8            	  364782	      3258 ns/op	    2992 B/op	      33 allocs/op
BenchmarkDecodeBlogStructEmptyBody
BenchmarkDecodeBlogStructEmptyBody-8   	  344191	      3236 ns/op	    2992 B/op	      33 allocs/op
BenchmarkDecodeAlphaSlice
BenchmarkDecodeAlphaSlice-8            	   10000	    118773 ns/op	   56507 B/op	    1324 allocs/op
BenchmarkDecodeAlphaStruct
BenchmarkDecodeAlphaStruct-8           	  126303	      9531 ns/op	    9226 B/op	      93 allocs/op
BenchmarkStatementMapTable
BenchmarkStatementMapTable-8           	  465386	      2499 ns/op	    3664 B/op	      33 allocs/op
```

After:
```
pkg: github.com/monzo/gocassa
BenchmarkDecodeBlogSliceNoBody
BenchmarkDecodeBlogSliceNoBody-8       	   42524	     29752 ns/op	   17232 B/op	     108 allocs/op
BenchmarkDecodeBlogStruct
BenchmarkDecodeBlogStruct-8            	  695108	      1559 ns/op	     736 B/op	       7 allocs/op
BenchmarkDecodeBlogStructEmptyBody
BenchmarkDecodeBlogStructEmptyBody-8   	  773036	      1586 ns/op	     736 B/op	       7 allocs/op
BenchmarkDecodeAlphaSlice
BenchmarkDecodeAlphaSlice-8            	   13658	     86213 ns/op	   30640 B/op	     208 allocs/op
BenchmarkDecodeAlphaStruct
BenchmarkDecodeAlphaStruct-8           	  263876	      4346 ns/op	    1132 B/op	      11 allocs/op
BenchmarkStatementMapTable
BenchmarkStatementMapTable-8           	  471937	      2551 ns/op	    3664 B/op	      33 allocs/op
```