### PR TITLE
Use a pointer to the mock table mutex

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -165,6 +165,7 @@ func (mo mockMultiOp) Preflight() error {
 
 func (ks *mockKeySpace) NewTable(name string, entity interface{}, fieldSource map[string]interface{}, keys Keys) Table {
 	mt := &MockTable{
+		RWMutex:     &sync.RWMutex{},
 		ksName:      ks.Name(),
 		tableName:   name,
 		entity:      entity,
@@ -191,7 +192,7 @@ func NewMockKeySpace() KeySpace {
 
 // MockTable implements the Table interface and stores rows in-memory.
 type MockTable struct {
-	sync.RWMutex
+	*sync.RWMutex
 
 	// rows is mapping from row key to column group key to column map
 	mtx         *sync.RWMutex
@@ -430,6 +431,7 @@ func (t *MockTable) Recreate() error {
 
 func (t *MockTable) WithOptions(o Options) Table {
 	return &MockTable{
+		RWMutex:     t.RWMutex,
 		ksName:      t.ksName,
 		tableName:   t.tableName,
 		rows:        t.rows,


### PR DESCRIPTION
## Problem
`(*MockTable).WithOptions` is [called frequently by the table helpers](https://github.com/monzo/gocassa/blob/1abfd4f7a2d9efd72c6a618226111fbe4ce5fc9b/multimap_multikey_table.go#L63-L70)

Each call to `WithOptions` instantiates a new instance of `*MockTable* copying all struct members from the receiver table **including a `sync.RWMutex**. Copying a `sync.RWMutex` creates a **new** mutex:

```
a := &thing{sync.Mutex{}}
b := &thing{a.Mutex}

a.Lock()
fmt.Println("locked a")
b.Lock()
fmt.Println("locked b")
```

This meant that the mutex was mostly not working which was causing transient test failures in CI.

## Solution
This PR replaces the `sync.Mutex` on `MockTable` with a `*sync.Mutex` to ensure we're always locking the same mutex
