### PR TITLE
Add ability to have sentinel values for Clustering Columns

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -6,17 +6,25 @@ import (
 	"time"
 )
 
+var (
+	// ClusteringSentinel represents a placeholder value to be used for cases
+	// where a value needs to be present (ie: a stand-in representing a
+	// clustering key that is empty)
+	ClusteringSentinel = "<gocassa.ClusteringSentinel>"
+)
+
 // SelectStatement represents a read (SELECT) query for some data in C*
 // It satisfies the Statement interface
 type SelectStatement struct {
-	keyspace       string                  // name of the keyspace
-	table          string                  // name of the table
-	fields         []string                // list of fields we want to select
-	where          []Relation              // where filter clauses
-	order          []ClusteringOrderColumn // order by clauses
-	limit          int                     // limit count, 0 means no limit
-	allowFiltering bool                    // whether we should allow filtering
-	keys           Keys                    // partition / clustering keys for table
+	keyspace             string                  // name of the keyspace
+	table                string                  // name of the table
+	fields               []string                // list of fields we want to select
+	where                []Relation              // where filter clauses
+	order                []ClusteringOrderColumn // order by clauses
+	limit                int                     // limit count, 0 means no limit
+	allowFiltering       bool                    // whether we should allow filtering
+	keys                 Keys                    // partition / clustering keys for table
+	allowClusterSentinel bool                    // whether we should enable our clustering sentinel
 }
 
 // NewSelectStatement adds the ability to craft a new SelectStatement
@@ -64,7 +72,7 @@ func (s SelectStatement) QueryAndValues() (string, []interface{}) {
 		fmt.Sprintf("FROM %s.%s", s.Keyspace(), s.Table()),
 	}
 
-	whereCQL, whereValues := generateWhereCQL(s.Relations())
+	whereCQL, whereValues := generateWhereCQL(s.Relations(), s.Keys(), s.allowClusterSentinel)
 	if whereCQL != "" {
 		query = append(query, "WHERE", whereCQL)
 		values = append(values, whereValues...)
@@ -161,14 +169,22 @@ func (s SelectStatement) Keys() Keys {
 	return s.keys
 }
 
+// WithClusteringSentinel allows you to specify whether the use of the
+// clustering sentinel value is enabled
+func (s SelectStatement) WithClusteringSentinel(enabled bool) SelectStatement {
+	s.allowClusterSentinel = enabled
+	return s
+}
+
 // InsertStatement represents an INSERT query to write some data in C*
 // It satisfies the Statement interface
 type InsertStatement struct {
-	keyspace string                 // name of the keyspace
-	table    string                 // name of the table
-	fieldMap map[string]interface{} // fields to be inserted
-	ttl      time.Duration          // ttl of the row
-	keys     Keys                   // partition / clustering keys for table
+	keyspace             string                 // name of the keyspace
+	table                string                 // name of the table
+	fieldMap             map[string]interface{} // fields to be inserted
+	ttl                  time.Duration          // ttl of the row
+	keys                 Keys                   // partition / clustering keys for table
+	allowClusterSentinel bool                   // whether we should enable our clustering sentinel
 }
 
 // NewInsertStatement adds the ability to craft a new InsertStatement
@@ -217,7 +233,11 @@ func (s InsertStatement) QueryAndValues() (string, []interface{}) {
 	for _, field := range sortedKeys(fieldMap) {
 		fieldNames = append(fieldNames, strings.ToLower(field))
 		placeholders = append(placeholders, "?")
-		values = append(values, fieldMap[field])
+		if isClusteringKeyField(field, s.keys) && s.allowClusterSentinel {
+			values = append(values, clusteringFieldOrSentinel(fieldMap[field]))
+		} else {
+			values = append(values, fieldMap[field])
+		}
 	}
 
 	query = append(query, "("+strings.Join(fieldNames, ", ")+")")
@@ -272,15 +292,23 @@ func (s InsertStatement) Keys() Keys {
 	return s.keys
 }
 
+// WithClusteringSentinel allows you to specify whether the use of the
+// clustering sentinel value is enabled
+func (s InsertStatement) WithClusteringSentinel(enabled bool) InsertStatement {
+	s.allowClusterSentinel = enabled
+	return s
+}
+
 // UpdateStatement represents an UPDATE query to update some data in C*
 // It satisfies the Statement interface
 type UpdateStatement struct {
-	keyspace string                 // name of the keyspace
-	table    string                 // name of the table
-	fieldMap map[string]interface{} // fields to be updated
-	where    []Relation             // where filter clauses
-	ttl      time.Duration          // ttl of the row
-	keys     Keys                   // partition / clustering keys for table
+	keyspace             string                 // name of the keyspace
+	table                string                 // name of the table
+	fieldMap             map[string]interface{} // fields to be updated
+	where                []Relation             // where filter clauses
+	ttl                  time.Duration          // ttl of the row
+	keys                 Keys                   // partition / clustering keys for table
+	allowClusterSentinel bool                   // whether we should enable our clustering sentinel
 }
 
 // NewUpdateStatement adds the ability to craft a new UpdateStatement
@@ -338,7 +366,7 @@ func (s UpdateStatement) QueryAndValues() (string, []interface{}) {
 	query = append(query, "SET", setCQL)
 	values = append(values, setValues...)
 
-	whereCQL, whereValues := generateWhereCQL(s.Relations())
+	whereCQL, whereValues := generateWhereCQL(s.Relations(), s.Keys(), s.allowClusterSentinel)
 	if whereCQL != "" {
 		query = append(query, "WHERE", whereCQL)
 		values = append(values, whereValues...)
@@ -392,13 +420,21 @@ func (s UpdateStatement) Keys() Keys {
 	return s.keys
 }
 
+// WithClusteringSentinel allows you to specify whether the use of the
+// clustering sentinel value is enabled
+func (s UpdateStatement) WithClusteringSentinel(enabled bool) UpdateStatement {
+	s.allowClusterSentinel = enabled
+	return s
+}
+
 // DeleteStatement represents a DELETE query to delete some data in C*
 // It satisfies the Statement interface
 type DeleteStatement struct {
-	keyspace string     // name of the keyspace
-	table    string     // name of the table
-	where    []Relation // where filter clauses
-	keys     Keys       // partition / clustering keys for table
+	keyspace             string     // name of the keyspace
+	table                string     // name of the table
+	where                []Relation // where filter clauses
+	keys                 Keys       // partition / clustering keys for table
+	allowClusterSentinel bool       // whether we should enable our clustering sentinel
 }
 
 // NewDeleteStatement adds the ability to craft a new DeleteStatement
@@ -439,7 +475,7 @@ func (s DeleteStatement) Values() []interface{} {
 // QueryAndValues returns the CQL query and any bind values
 func (s DeleteStatement) QueryAndValues() (string, []interface{}) {
 	query := fmt.Sprintf("DELETE FROM %s.%s", s.Keyspace(), s.Table())
-	whereCQL, whereValues := generateWhereCQL(s.Relations())
+	whereCQL, whereValues := generateWhereCQL(s.Relations(), s.Keys(), s.allowClusterSentinel)
 	if whereCQL != "" {
 		query += " WHERE " + whereCQL
 	}
@@ -465,6 +501,13 @@ func (s DeleteStatement) Relations() []Relation {
 // Keys provides the Partition / Clustering keys defined by the table recipe
 func (s DeleteStatement) Keys() Keys {
 	return s.keys
+}
+
+// WithClusteringSentinel allows you to specify whether the use of the
+// clustering sentinel value is enabled
+func (s DeleteStatement) WithClusteringSentinel(enabled bool) DeleteStatement {
+	s.allowClusterSentinel = enabled
+	return s
 }
 
 // cqlStatement represents a statement that executes raw CQL
@@ -509,20 +552,23 @@ func generateUpdateSetCQL(fm map[string]interface{}) (string, []interface{}) {
 // a WHERE clause. An expected output may be something like:
 //	- "foo = ?", {1}
 //	- "foo = ? AND bar IN ?", {1, {"a", "b", "c"}}
-func generateWhereCQL(rs []Relation) (string, []interface{}) {
+func generateWhereCQL(rs []Relation, keys Keys, allowClusterSentinel bool) (string, []interface{}) {
 	clauses, values := make([]string, 0, len(rs)), make([]interface{}, 0, len(rs))
 	for _, relation := range rs {
-		clause, bindValue := generateRelationCQL(relation)
+		clause, bindValue := generateRelationCQL(relation, keys, allowClusterSentinel)
 		clauses = append(clauses, clause)
 		values = append(values, bindValue)
 	}
 	return strings.Join(clauses, " AND "), values
 }
 
-func generateRelationCQL(rel Relation) (string, interface{}) {
+func generateRelationCQL(rel Relation, keys Keys, allowClusterSentinel bool) (string, interface{}) {
 	field := strings.ToLower(rel.Field())
 	switch rel.Comparator() {
 	case CmpEquality:
+		if isClusteringKeyField(rel.Field(), keys) && allowClusterSentinel {
+			return field + " = ?", clusteringFieldOrSentinel(rel.Terms()[0])
+		}
 		return field + " = ?", rel.Terms()[0]
 	case CmpIn:
 		return field + " IN ?", rel.Terms()
@@ -551,4 +597,34 @@ func generateOrderByCQL(order []ClusteringOrderColumn) string {
 		out = append(out, oc.Column+" "+oc.Direction.String())
 	}
 	return strings.Join(out, ", ")
+}
+
+// isClusteringKeyField determines whether the relation makes up the
+// clustering key of the statement
+func isClusteringKeyField(field string, keys Keys) bool {
+	for _, key := range keys.ClusteringColumns {
+		if strings.ToLower(key) == strings.ToLower(field) {
+			return true
+		}
+	}
+	return false
+}
+
+// clusteringFieldOrSentinel will check if we should substitute in our
+// sentinel value for empty clustering fields
+func clusteringFieldOrSentinel(term interface{}) interface{} {
+	switch v := term.(type) {
+	case string:
+		if len(v) == 0 {
+			return ClusteringSentinel
+		}
+		return v
+	case []byte:
+		if len(v) == 0 {
+			return []byte(ClusteringSentinel)
+		}
+		return v
+	default:
+		return term
+	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectStatement(t *testing.T) {
@@ -108,52 +109,158 @@ func TestDeleteStatement(t *testing.T) {
 	assert.Equal(t, []interface{}{"bar", []interface{}{"a", "b", "c"}}, stmt.Values())
 }
 
+func TestStatementsWithSentinel(t *testing.T) {
+	t.Run("SelectStatement", func(t *testing.T) {
+		fields := []string{"a", "b", "c"}
+		keys := Keys{PartitionKeys: []string{"a"}, ClusteringColumns: []string{"b"}}
+		stmt, err := NewSelectStatement("ks1", "tbl1", fields, nil, keys)
+		require.NoError(t, err)
+
+		stmt = stmt.WithRelations([]Relation{
+			Eq("a", "hello"),
+			Eq("b", ""),
+		})
+		assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"hello", ""}, stmt.Values())
+
+		stmt = stmt.WithRelations([]Relation{
+			Eq("a", ""),
+			Eq("b", ""),
+		})
+		stmt = stmt.WithClusteringSentinel(true)
+		assert.Equal(t, "SELECT a, b, c FROM ks1.tbl1 WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"", ClusteringSentinel}, stmt.Values())
+	})
+
+	t.Run("InsertStatement", func(t *testing.T) {
+		fieldMap := map[string]interface{}{"a": "", "b": "", "c": ""}
+		keys := Keys{PartitionKeys: []string{"a"}, ClusteringColumns: []string{"b"}}
+
+		stmt, err := NewInsertStatement("ks1", "tbl1", fieldMap, keys)
+		assert.NoError(t, err)
+		assert.Equal(t, "INSERT INTO ks1.tbl1 (a, b, c) VALUES (?, ?, ?)", stmt.Query())
+		assert.Equal(t, []interface{}{"", "", ""}, stmt.Values())
+
+		stmt = stmt.WithClusteringSentinel(true)
+		assert.Equal(t, "INSERT INTO ks1.tbl1 (a, b, c) VALUES (?, ?, ?)", stmt.Query())
+		assert.Equal(t, []interface{}{"", ClusteringSentinel, ""}, stmt.Values())
+	})
+
+	t.Run("UpdateStatement", func(t *testing.T) {
+		fieldMap := map[string]interface{}{"c": ""}
+		keys := Keys{PartitionKeys: []string{"a"}, ClusteringColumns: []string{"b"}}
+		relations := []Relation{
+			Eq("a", ""),
+			Eq("b", ""),
+		}
+
+		stmt, err := NewUpdateStatement("ks1", "tbl1", fieldMap, relations, keys)
+		assert.NoError(t, err)
+		assert.Equal(t, "UPDATE ks1.tbl1 SET c = ? WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"", "", ""}, stmt.Values())
+
+		stmt = stmt.WithClusteringSentinel(true)
+		assert.Equal(t, "UPDATE ks1.tbl1 SET c = ? WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"", "", ClusteringSentinel}, stmt.Values())
+	})
+
+	t.Run("DeleteStatement", func(t *testing.T) {
+		keys := Keys{PartitionKeys: []string{"a"}, ClusteringColumns: []string{"b"}}
+		relations := []Relation{
+			Eq("a", ""),
+			Eq("b", ""),
+		}
+
+		stmt, err := NewDeleteStatement("ks1", "tbl1", relations, keys)
+		assert.NoError(t, err)
+		assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"", ""}, stmt.Values())
+
+		stmt = stmt.WithClusteringSentinel(true)
+		assert.Equal(t, "DELETE FROM ks1.tbl1 WHERE a = ? AND b = ?", stmt.Query())
+		assert.Equal(t, []interface{}{"", ClusteringSentinel}, stmt.Values())
+	})
+}
+
 func TestGenerateWhereCQL(t *testing.T) {
 	stmt, values := generateWhereCQL([]Relation{
 		Eq("foo", "bar"),
-	})
+	}, Keys{}, false)
 	assert.Equal(t, "foo = ?", stmt)
 	assert.Equal(t, []interface{}{"bar"}, values)
 
 	stmt, values = generateWhereCQL([]Relation{
 		Eq("foo", "bar"),
 		In("baz", "a", "b", "c"),
-	})
+	}, Keys{}, false)
 	assert.Equal(t, "foo = ? AND baz IN ?", stmt)
 	assert.Equal(t, []interface{}{"bar", []interface{}{"a", "b", "c"}}, values)
+
+	stmt, values = generateWhereCQL([]Relation{
+		Eq("foo", "bar"),
+	}, Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, []interface{}{"bar"}, values)
+
+	stmt, values = generateWhereCQL([]Relation{
+		Eq("foo", ""),
+	}, Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, []interface{}{ClusteringSentinel}, values)
+
+	stmt, values = generateWhereCQL([]Relation{
+		Eq("bar", ""),
+	}, Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "bar = ?", stmt)
+	assert.Equal(t, []interface{}{""}, values)
 }
 
 func TestGenerateRelationCQL(t *testing.T) {
-	stmt, value := generateRelationCQL(Eq("foo", "bar"))
+	stmt, value := generateRelationCQL(Eq("foo", "bar"), Keys{}, false)
 	assert.Equal(t, "foo = ?", stmt)
 	assert.Equal(t, "bar", value)
 
-	stmt, value = generateRelationCQL(Eq("FoO", "BAR"))
+	stmt, value = generateRelationCQL(Eq("FoO", "BAR"), Keys{}, false)
 	assert.Equal(t, "foo = ?", stmt)
 	assert.Equal(t, "BAR", value)
 
-	stmt, value = generateRelationCQL(In("foo", "a", "b", "c"))
+	stmt, value = generateRelationCQL(Eq("foo", ""),
+		Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, ClusteringSentinel, value)
+
+	stmt, value = generateRelationCQL(Eq("FoO", ""),
+		Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, ClusteringSentinel, value)
+
+	stmt, value = generateRelationCQL(Eq("FoO", 0),
+		Keys{ClusteringColumns: []string{"foo"}}, true)
+	assert.Equal(t, "foo = ?", stmt)
+	assert.Equal(t, 0, value)
+
+	stmt, value = generateRelationCQL(In("foo", "a", "b", "c"), Keys{}, false)
 	assert.Equal(t, "foo IN ?", stmt)
 	assert.Equal(t, []interface{}{"a", "b", "c"}, value)
 
-	stmt, value = generateRelationCQL(GT("foo", 1))
+	stmt, value = generateRelationCQL(GT("foo", 1), Keys{}, false)
 	assert.Equal(t, "foo > ?", stmt)
 	assert.Equal(t, 1, value)
 
-	stmt, value = generateRelationCQL(GTE("foo", 1))
+	stmt, value = generateRelationCQL(GTE("foo", 1), Keys{}, false)
 	assert.Equal(t, "foo >= ?", stmt)
 	assert.Equal(t, 1, value)
 
-	stmt, value = generateRelationCQL(LT("foo", 1))
+	stmt, value = generateRelationCQL(LT("foo", 1), Keys{}, false)
 	assert.Equal(t, "foo < ?", stmt)
 	assert.Equal(t, 1, value)
 
-	stmt, value = generateRelationCQL(LTE("foo", 1))
+	stmt, value = generateRelationCQL(LTE("foo", 1), Keys{}, false)
 	assert.Equal(t, "foo <= ?", stmt)
 	assert.Equal(t, 1, value)
 
 	assert.PanicsWithValue(t, "unknown comparator -1", func() {
-		stmt, value = generateRelationCQL(Relation{cmp: -1})
+		stmt, value = generateRelationCQL(Relation{cmp: -1}, Keys{}, false)
 	})
 }
 
@@ -171,4 +278,16 @@ func TestGenerateOrderByCQL(t *testing.T) {
 		{Column: "bar", Direction: DESC},
 	})
 	assert.Equal(t, "foo ASC, bar DESC", stmt)
+}
+
+func TestClusteringFieldOrSentinel(t *testing.T) {
+	assert.Equal(t, ClusteringSentinel, clusteringFieldOrSentinel(""))
+	assert.Equal(t, "foo", clusteringFieldOrSentinel("foo"))
+
+	assert.Equal(t, []byte(ClusteringSentinel), clusteringFieldOrSentinel([]byte{}))
+	assert.Equal(t, []byte{0x00}, clusteringFieldOrSentinel([]byte{0x00}))
+
+	assert.Equal(t, 0, clusteringFieldOrSentinel(0))
+	assert.Equal(t, 42, clusteringFieldOrSentinel(42))
+	assert.Equal(t, struct{}{}, clusteringFieldOrSentinel(struct{}{}))
 }


### PR DESCRIPTION
In services like Keyspaces, it is not permitted to have empty string/blob clustering values. This PR introduces a sentinel value that can stand-in in these cases because applications may wish to have empty values (since Cassandra _does_ allow you to do so)