### PR TITLE
Remove tests for MultiMap MultiRead which shouldn't still be present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.14.x
-  - 1.15.x
+  - 1.16.x
+  - 1.17.x
   - tip
 
 addons:

--- a/mock_test.go
+++ b/mock_test.go
@@ -326,15 +326,6 @@ func (s *MockSuite) TestMultiMapTableRead() {
 	s.Equal("Joe", u.Name)
 }
 
-func (s *MockSuite) TestMultiMapTableMultiRead() {
-	s.insertUsers()
-	var users []user
-	s.NoError(s.mmapTbl.MultiRead(1, []interface{}{1, 2}, &users).Run())
-	s.Len(users, 2)
-	s.Equal("Jane", users[0].Name)
-	s.Equal("Joe", users[1].Name)
-}
-
 func (s *MockSuite) TestMultiMapTableList() {
 	s.insertUsers()
 	var users []user

--- a/multimap_table_test.go
+++ b/multimap_table_test.go
@@ -88,43 +88,6 @@ func TestMultimapTableDelete(t *testing.T) {
 	}
 }
 
-func TestMultimapTableMultiRead(t *testing.T) {
-	tbl := ns.MultimapTable("customer93", "Tag", "Id", Customer2{})
-	createIf(tbl.(TableChanger), t)
-	joe := Customer2{
-		Id:   "33",
-		Name: "Joe",
-		Tag:  "A",
-	}
-	err := tbl.Set(joe).Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-	jane := Customer2{
-		Id:   "34",
-		Name: "Jane",
-		Tag:  "A",
-	}
-	err = tbl.Set(jane).Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-	customers := &[]Customer2{}
-	err = tbl.MultiRead("A", []interface{}{"33", "34"}, customers).Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(*customers) != 2 {
-		t.Fatalf("Expected to multiread 2 records, got %d", len(*customers))
-	}
-	if !reflect.DeepEqual((*customers)[0], joe) {
-		t.Fatalf("Expected to find joe, got %v", (*customers)[0])
-	}
-	if !reflect.DeepEqual((*customers)[1], jane) {
-		t.Fatalf("Expected to find jane, got %v", (*customers)[1])
-	}
-}
-
 func TestMultimapTableMultiListOrder(t *testing.T) {
 	tbl := ns.MultimapTable("customer93", "Tag", "Id", Customer2{})
 	createIf(tbl.(TableChanger), t)


### PR DESCRIPTION
This PR cleans up the tests which weren't building when we removed MultiRead support for clustering columns in  https://github.com/monzo/gocassa/pull/73