### PR TITLE
Read and propagate error from our iterator when decoding into slice

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -87,8 +87,11 @@ func (s *scanner) iterSlice(iter Scannable) (int, error) {
 		sliceElem.Set(reflect.Append(sliceElem, wrapPtrValue(outVal, sliceElemType)))
 		rowsScanned++
 	}
-
 	s.rowsScanned += rowsScanned
+
+	if err := iter.Err(); err != nil {
+		return rowsScanned, err
+	}
 	return rowsScanned, nil
 }
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -117,6 +117,16 @@ func TestScanIterSlice(t *testing.T) {
 	_, err = NewScanner(stmt, &i1).ScanIter(iter)
 	assert.Error(t, err)
 	iter.Reset()
+
+	// Test decoding with an error
+	var j1 []fakeStruct
+	errorerIter := newMockIterator([]map[string]interface{}{}, stmt.fields)
+	errorScanner := NewScanner(stmt, &j1)
+	expectedErr := fmt.Errorf("Something went baaaad")
+	errorerIter.err = expectedErr
+	rowsRead, err = errorScanner.ScanIter(errorerIter)
+	assert.Equal(t, 0, rowsRead)
+	assert.Equal(t, err, expectedErr)
 }
 
 func TestScanIterStruct(t *testing.T) {


### PR DESCRIPTION
If we spot an error when decoding from the slice use case, we should return an error upstream. This makes our decoding consistent between the slice and struct use case.