### PR TITLE
Add a GitHub Action for running tests

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,35 @@
+name: Run Tests
+on: 
+  - pull_request
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - uses: actions/checkout@v3
+    - name: Install OpenJDK
+      run: |
+        sudo apt-get update && sudo apt-get install -y openjdk-8-jdk-headless
+        sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+        export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+        java -version
+
+    - name: Downloading Cassandra
+      run: |
+        sudo rm -rf /var/lib/cassandra/*
+        wget https://archive.apache.org/dist/cassandra/3.0.22/apache-cassandra-3.0.22-bin.tar.gz && tar -xvzf apache-cassandra-3.0.22-bin.tar.gz
+
+    - name: Run Tests
+      run: |
+        echo "Starting Cassandra"
+        sudo sh ./apache-cassandra-3.0.22/bin/cassandra -R
+        sleep 20
+        echo "Started Cassandra"
+        go test -v ./...

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,28 +8,18 @@ jobs:
         go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    services:
+      cassandra:
+        image: cassandra:3.0.22
+        ports:
+          - 9042:9042
+        options: --health-cmd "cqlsh --debug" --health-interval 5s --health-retries 10
 
     steps:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@v3
-    - name: Install OpenJDK
-      run: |
-        sudo apt-get update && sudo apt-get install -y openjdk-8-jdk-headless
-        sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
-        export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-        java -version
-
-    - name: Downloading Cassandra
-      run: |
-        sudo rm -rf /var/lib/cassandra/*
-        wget https://archive.apache.org/dist/cassandra/3.0.22/apache-cassandra-3.0.22-bin.tar.gz && tar -xvzf apache-cassandra-3.0.22-bin.tar.gz
-
     - name: Run Tests
       run: |
-        echo "Starting Cassandra"
-        sudo sh ./apache-cassandra-3.0.22/bin/cassandra -R
-        sleep 20
-        echo "Started Cassandra"
         go test -v ./...


### PR DESCRIPTION
Our integration with TravisCI seems to have expired. This PR migrates the entire testing to GitHub Actions instead.