### PR TITLE
Add comment for the List functions

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -98,6 +98,8 @@ type MultimapTable interface {
 	Update(value, id interface{}, valuesToUpdate map[string]interface{}) Op
 	Delete(value, id interface{}) Op
 	DeleteAll(value interface{}) Op
+	// List populates the provided pointer to a slice with the results matching the keys provided.
+	// To disable the limit, set limit to 0 (although note that cassandra has a default limit of 10000)
 	List(partitionKey, clusteringKey interface{}, limit int, pointerToASlice interface{}) Op
 	Read(partitionKey, clusteringKey, pointer interface{}) Op
 	WithOptions(Options) MultimapTable
@@ -112,6 +114,8 @@ type MultimapMkTable interface {
 	Update(v, id map[string]interface{}, valuesToUpdate map[string]interface{}) Op
 	Delete(v, id map[string]interface{}) Op
 	DeleteAll(v map[string]interface{}) Op
+	// List populates the provided pointer to a slice with the results matching the keys provided.
+	// To disable the limit, set limit to 0 (although note that cassandra has a default limit of 10000)
 	List(v, startId map[string]interface{}, limit int, pointerToASlice interface{}) Op
 	Read(v, id map[string]interface{}, pointer interface{}) Op
 	MultiRead(v, id map[string]interface{}, pointerToASlice interface{}) Op

--- a/interfaces.go
+++ b/interfaces.go
@@ -99,7 +99,7 @@ type MultimapTable interface {
 	Delete(value, id interface{}) Op
 	DeleteAll(value interface{}) Op
 	// List populates the provided pointer to a slice with the results matching the keys provided.
-	// To disable the limit, set limit to 0 (although note that cassandra has a default limit of 10000)
+	// To disable the limit, set limit to 0
 	List(partitionKey, clusteringKey interface{}, limit int, pointerToASlice interface{}) Op
 	Read(partitionKey, clusteringKey, pointer interface{}) Op
 	WithOptions(Options) MultimapTable
@@ -115,7 +115,7 @@ type MultimapMkTable interface {
 	Delete(v, id map[string]interface{}) Op
 	DeleteAll(v map[string]interface{}) Op
 	// List populates the provided pointer to a slice with the results matching the keys provided.
-	// To disable the limit, set limit to 0 (although note that cassandra has a default limit of 10000)
+	// To disable the limit, set limit to 0
 	List(v, startId map[string]interface{}, limit int, pointerToASlice interface{}) Op
 	Read(v, id map[string]interface{}, pointer interface{}) Op
 	MultiRead(v, id map[string]interface{}, pointerToASlice interface{}) Op


### PR DESCRIPTION
The question "What should the limit value be set to, in order to disable the limit" has been asked of me many times, and I've never had a good answer.

I've seen this set to -1 and 0 in various pieces of code, so decided to find out definitively so took a look through the code. I found the following comment `// limit count, 0 means no limit` in [statments.go](https://github.com/monzo/gocassa/blob/master/statement.go#L31), and further looking [revealed an if statement that returns 0 if limit < 1.](https://github.com/monzo/gocassa/blob/master/statement.go#L155-L157).

Popping a comment above the function should help reduce the uncertainty that people seems to have when using List with no limit.

Please validate the rest of the comment I've added, I'm certainly no cassandra or gocassa expert.