### PR TITLE
Add support for DESC clustering order in the mock.

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -247,8 +247,9 @@ func (t gocqlTypeInfo) Custom() string {
 }
 
 type keyPart struct {
-	Key   string
-	Value interface{}
+	Key             string
+	Value           interface{}
+	ClusteringOrder ColumnDirection
 }
 
 func (k *keyPart) Bytes() []byte {
@@ -270,6 +271,9 @@ func (k key) Less(other key) bool {
 		cmp := bytes.Compare(k[i].Bytes(), other[i].Bytes())
 		if cmp == 0 {
 			continue
+		}
+		if k[i].ClusteringOrder { // desc
+			return cmp > 0
 		}
 		return cmp < 0
 	}
@@ -294,7 +298,7 @@ func (k key) ToSuperColumn() *superColumn {
 func (k key) Append(column string, value interface{}) key {
 	newKey := make([]keyPart, len(k)+1)
 	copy(newKey, k)
-	newKey[len(k)] = keyPart{column, value}
+	newKey[len(k)] = keyPart{Key: column, Value: value}
 	return newKey
 }
 
@@ -363,6 +367,16 @@ func (t *MockTable) getOrCreateRow(rowKey key) *btree.BTree {
 func (t *MockTable) getOrCreateColumnGroup(rowKey, superColumnKey key) map[string]interface{} {
 	row := t.getOrCreateRow(rowKey)
 	scol := superColumnKey.ToSuperColumn()
+
+	// Retrieve the clustering order from the table options
+	// and assign to the key parts to set the sort ordering on each column
+	keyOrder := make(map[string]ColumnDirection, 0)
+	for _, v := range t.options.ClusteringOrder {
+		keyOrder[v.Column] = v.Direction
+	}
+	for i, kp := range scol.Key {
+		scol.Key[i].ClusteringOrder = keyOrder[kp.Key]
+	}
 
 	if row.Has(scol) {
 		return row.Get(scol).(*superColumn).Columns


### PR DESCRIPTION
This is an exact copy of [Matt's original PR](https://github.com/monzo/gocassa/pull/65) (plus a test), that was reverted due to failing unit tests in services. These tests have been fixed and are waiting on this change to be merged. 