### PR TITLE
Remove unnecessary allocation around sentinel checks for reflect.Struct

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     services:


### PR DESCRIPTION
We don't need to constantly allocate a new time.Time each we evaluate this path, just to get the reflect.Type