### PR TITLE
Add support for custom types in generator

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -105,6 +105,10 @@ func j(s []string) string {
 	return strings.Join(s1, ", ")
 }
 
+type CQLTyper interface {
+	CQLType() gocql.Type
+}
+
 func cassaType(i interface{}) gocql.Type {
 	switch i.(type) {
 	case int, int32:
@@ -146,6 +150,11 @@ func cassaType(i interface{}) gocql.Type {
 		return gocql.TypeDouble
 	case reflect.Bool:
 		return gocql.TypeBoolean
+	}
+
+	// Check if the field implements the CQLTyper interface
+	if v, ok := i.(CQLTyper); ok {
+		return v.CQLType()
 	}
 
 	return gocql.TypeCustom

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,33 @@
+package gocassa
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/monzo/gocassa/reflect"
+)
+
+type customType struct {
+	foo string
+}
+
+func (ct customType) CQLType() gocql.Type {
+	return gocql.TypeVarchar
+}
+
+// TestGoCassaType_CustomType tests that cassaType supports identifying the
+// C* type for a custom type that implements the CQLTyper interface
+func TestGoCassaType_CustomType(t *testing.T) {
+	var testRow = struct {
+		Field customType
+	}{}
+
+	m, ok := reflect.StructToMap(testRow)
+	require.True(t, ok)
+
+	typ := cassaType(m["Field"])
+	assert.Equal(t, gocql.TypeVarchar, typ)
+}


### PR DESCRIPTION
You can use custom field types with gocassa if they implement either the `gocql.Marshaler` and `gocql.Unmarshaler` interfaces or the `gocql.UDTMarshaler` and `gocql.UDTUnmarshaler` interfaces. However, Gocassa's generation code (the code that generates a `CREATE IF NOT EXISTS` statement errors if you call them on a table that uses such a type. It errors because it needs to know what C* type should be used and it doesn't know. At Monzo this means that any service that uses fields of type `*decimal.Decimal` or `*decimal.Money` cannot make use of the generator. This PR introduces a new `CQLTyper` to accompany the `Marshaler` and `Unmarshaler` that can be used to allow gocassa to obtain this information.