### PR TITLE
Allow empty Noop() to be added to mock op chains

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -135,6 +135,11 @@ func (mo mockMultiOp) Add(inOps ...Op) Op {
 			ops = append(ops, op...)
 		case mockOp:
 			ops = append(ops, op)
+		case multiOp:
+			if len(op) == 0 {
+				continue
+			}
+			panic("can't Add non-mock ops to mockMultiOp")
 		default:
 			panic("can't Add non-mock ops to mockMultiOp")
 		}

--- a/mock_test.go
+++ b/mock_test.go
@@ -514,6 +514,20 @@ func (s *MockSuite) TestNoop() {
 	s.Equal("Jill", users[1].Name)
 }
 
+// Don't panic when adding an empty Noop to an existing op chain
+func (s *MockSuite) TestEmptyNoop() {
+	addresses := s.insertAddresses()
+	addressToUpdate := addresses[0]
+	addressToUpdate.PostCode = "XYZ"
+	emptyNoop := Noop()
+	op := s.embMapTbl.Set(addressToUpdate)
+	op = op.Add(s.embTsTbl.Set(addressToUpdate))
+	s.NotPanics(func() {
+		op = op.Add(emptyNoop)
+	})
+	s.NoError(op.Run())
+}
+
 func (s *MockSuite) TestEmbedMapRead() {
 	expectedAddresses := s.insertAddresses()
 


### PR DESCRIPTION
Currently, if you add a `gocassa.Noop()` to an existing chain of mock operations we throw a panic `can't Add non-mock ops to mockMultiOp`. This is because the type of an empty `Noop()` is `multiOp`, however without any operations in it this won't do anything. This means we can't mock/test code paths that could have an empty `Noop()`, overly simplified example;

```go
func UpdateItemDescription(item *Item, newDescription string) error {
	op := gocassa.Noop()
	if item.Description != newDescription {
		item.Description = newDescription
		op.Add(itemsById.Set(item))
	}
	return op.Run()
}
```

In this PR, we now check if the length of the multiOp is 0 and if it is continue without panicking.

I've added a test case for this, which before the change to `mock.go` was failing

```
$ go test -run TestRunMockSuite/TestEmptyNoop ./...
--- FAIL: TestRunMockSuite (0.00s)
    --- FAIL: TestRunMockSuite/TestEmptyNoop (0.00s)
        mock_test.go:525:
                Error Trace:    mock_test.go:525
                Error:          func (assert.PanicTestFunc)(0x100e568a0) should not panic
                                        Panic value:    can't Add non-mock ops to mockMultiOp
```

This now passes