### PR TITLE
Fix bug when defining multi time-series tables with the same time field and clustering key

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -124,10 +124,14 @@ func (k *k) MultiTimeSeriesTable(name, indexField, timeField, idField string, bu
 		panic("Unrecognized row type")
 	}
 	m[bucketFieldName] = time.Now()
+	clusteringColumns := []string{timeField}
+	if idField != timeField {
+		clusteringColumns = append(clusteringColumns, idField)
+	}
 	return &multiTimeSeriesT{
 		t: k.NewTable(fmt.Sprintf("%s_multiTimeSeries_%s_%s_%s_%s", name, indexField, timeField, idField, bucketSize.String()), row, m, Keys{
 			PartitionKeys:     []string{indexField, bucketFieldName},
-			ClusteringColumns: []string{timeField, idField},
+			ClusteringColumns: clusteringColumns,
 		}),
 		indexField: indexField,
 		timeField:  timeField,


### PR DESCRIPTION
This pull request fixes a bug which made it impossible to add non-nullable data to a multi time-series table, which is defined with the same time field and clustering key.

### Steps to replicate

Define a table in CQL, with a timestamp clustering column and the same timestamp used for [clustering order](https://docs.datastax.com/en/cql-oss/3.1/cql/cql_reference/refClstrOrdr.html), example:

```
CREATE TABLE IF NOT EXISTS presence.presence (
   userid varchar,
   created timestamp,
   bucket timestamp,
   PRIMARY KEY ((userid, bucket), created)
) WITH compaction = {
    'class': 'TimeWindowCompactionStrategy',
    'compaction_window_unit' : 'MINUTES',
    'compaction_window_size' : 30
} AND default_time_to_live = 1800 // 30 minutes
AND CLUSTERING ORDER BY (created DESC);
```

Define the Gocassa interface to that table:

```
presenceTable = Keyspace.MultiTimeSeriesTable(
    "presence",
    "UserID",
    "Created", // timeField
    "Created", // clusteringKey
    presenceBucketSize,
    domain.Presence{},
).WithOptions(gocassa.Options{TableName: "presence"})
```

✅ Try to insert data into that table, it will succeed, executing a Cassandra `INSERT` operation to save the data:

https://github.com/monzo/gocassa/blob/35e7d70075525f25cce50a32d0dcdeb5ec904006/table.go#L137-L141

Now create that same table, with a new non-primary key, non-nullable column (or add the column to the existing table):

```
CREATE TABLE IF NOT EXISTS presence.presence (
   userid varchar,
   created timestamp,
   bucket timestamp,
   pagename text, // not part of the primary key and not nullable
   PRIMARY KEY ((userid, bucket), created)
) WITH compaction = {
    'class': 'TimeWindowCompactionStrategy',
    'compaction_window_unit' : 'MINUTES',
    'compaction_window_size' : 30
} AND default_time_to_live = 1800 // 30 minutes
AND CLUSTERING ORDER BY (created DESC);
```

Define the Gocassa interface to that table:

```
presenceTable = Keyspace.MultiTimeSeriesTable(
    "presence",
    "UserID",
    "Created", // timeField
    "Created", // clusteringKey
    presenceBucketSize,
    domain.Presence{}, // now includes a 'pagename' field, which is not part of the primary key and not nullable
).WithOptions(gocassa.Options{TableName: "presence"})
```

And when we try to insert data into that table, against a real Cassandra instance, we'll see this error:

```
{
    "cassandra_clustering_key_hash": "0",
    "cassandra_keyspace": "presence",
    "cassandra_partition_key_hash": "3812829176885720974",
    "cassandra_query": "UPDATE presence.presence USING TTL ? SET pagename = ? WHERE userid = ? AND bucket = ? AND created = ? AND created = ?",
    "cassandra_stmt_type": "update",
    "cassandra_table": "presence",
    "cql_error_code": "0x2200",
    "cql_error_message": "created cannot be restricted by more than one relation if it includes an Equal"
}
```

Note that gocassa has used an `UPDATE` operation rather than an `INSERT` operation, this is chosen when there are non-nullable non-primary key columns being set: https://github.com/monzo/gocassa/blob/35e7d70075525f25cce50a32d0dcdeb5ec904006/table.go#L137-L141

You see in the `cassandra_query` that we're trying to restrict our UPDATE query by two `created = ?` relations, resulting in this `created cannot be restricted by more than one relation if it includes an Equal` error.

This happens because the `relations` for an `UPDATE` operation are defined based on Gocassa's internal understanding of the clustering keys and concatenating these with the partition keys.

Gocassa currently considers the clustering keys to be a concatenation of the clustering key from our primary key _and_ the time field -- Even if these are the same column, like in the above example.

So this pull request handles this case, to avoid defining duplicate relations in the case that our time field and clustering key are the same column.

With this PR applied locally, I'm able to successfully run `UPDATE` insertions into the above table with the non-nullable non-primary key column.

### What's next?

I think this will affect other time series tables in Gocassa, but I'm keeping the scope of this PR as narrow as possible for now.