### PR TITLE
Make clustering order column lowercase in generator

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -68,7 +68,7 @@ func createTableStmt(createStmt, keySpace, cf string, partitionKeys, colKeys []s
 	if len(order) > 0 {
 		orderStrs := make([]string, len(order))
 		for i, o := range order {
-			orderStrs[i] = fmt.Sprintf("%v %v", o.Column, o.Direction.String())
+			orderStrs[i] = fmt.Sprintf("%v %v", strings.ToLower(o.Column), o.Direction.String())
 		}
 		orderLine := fmt.Sprintf("WITH CLUSTERING ORDER BY (%v)", strings.Join(orderStrs, ", "))
 		lines = append(lines, orderLine)


### PR DESCRIPTION
As part of [adding support for custom cluster ordering to `gen-dao`](https://github.com/monzo/wearedev/compare/add-gen-dao-support-for-custom-ordering?expand=1), I discovered that the generated cql file has a title case clustering order column, which doesn't seem right.