### PR TITLE
Add support for query-level DESC clustering order in the mock

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -625,6 +625,13 @@ func (q *MockFilter) Read(out interface{}) Op {
 			return err
 		}
 
+		// If a query-level clustering order has been provided, and the first one is descending, reverse the list
+		if len(m.options.ClusteringOrder) > 0 && m.options.ClusteringOrder[0].Direction == DESC {
+			for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+				result[i], result[j] = result[j], result[i]
+			}
+		}
+
 		opt := q.table.options.Merge(m.options)
 		if opt.Limit > 0 && opt.Limit < len(result) {
 			result = result[:opt.Limit]

--- a/mock_test.go
+++ b/mock_test.go
@@ -347,6 +347,14 @@ func (s *MockSuite) TestMultiMapTableList() {
 	s.NoError(s.mmapTbl.List(1, 2, 1, &users).Run())
 	s.Len(users, 1)
 	s.Equal("Joe", users[0].Name)
+
+	// Order DESC
+	s.NoError(s.mmapTbl.List(1, 0, 10, &users).WithOptions(Options{
+		ClusteringOrder: []ClusteringOrderColumn{{Column: "Name", Direction: DESC}},
+	}).Run())
+	s.Len(users, 2)
+	s.Equal("Joe", users[0].Name)
+	s.Equal("Jane", users[1].Name)
 }
 
 func (s *MockSuite) TestMultiMapTableUpdate() {


### PR DESCRIPTION
I'm currently adding support to `gen-dao` for allowing the sort order used by the generated List function to be reversed. Whilst doing so, I noticed that the gocassa mocking doesn't currently respect the provided clustering order.

We've previously added mock support for clustering order at table creation (https://github.com/monzo/gocassa/pull/82), but not as part of a query.

See https://github.com/monzo/wearedev/pull/172946 for the `gen-dao` change.